### PR TITLE
Cleaned up literature.bib.

### DIFF
--- a/literature.bib
+++ b/literature.bib
@@ -10,7 +10,7 @@ author = {Aakvik, Arild and Heckman, James J and Vytlacil, Edward J},
 journal = {Journal of Econometrics},
 number = {1-2},
 pages = {15--51},
-title = {{{\{}T{\}}reatment {\{}E{\}}ffects for {\{}D{\}}iscrete {\{}O{\}}utcomes {\{}W{\}}hen {\{}R{\}}esponses to {\{}T{\}}reatment {\{}V{\}}ary {\{}A{\}}mong {\{}O{\}}bservationally {\{}I{\}}dentical {\{}P{\}}ersons: {\{}A{\}}n {\{}A{\}}pplication to {\{}N{\}}orwegian {\{}V{\}}ocational {\{}R{\}}ehabilitation {\{}P{\}}rograms}},
+title = {{Treatment Effects for Discrete Outcomes When Responses to Treatment Vary Among Observationally Identical Persons: An Application to Norwegian Vocational Rehabilitation Programs}},
 volume = {125},
 year = {2005}
 }
@@ -113,7 +113,7 @@ keywords = {Anticipation,Bivariate duration analysis,Hazard rate,Partial likelih
 number = {5},
 pages = {1491--1517},
 title = {{The nonparametric identification of treatment effects in duration models}},
-url = {http://www.scopus.com/inward/record.url?eid=2-s2.0-0141938466{\&}partnerID=tZOtx3y1},
+url = {http://www.scopus.com/inward/record.url?eid=2-s2.0-0141938466&partnerID=tZOtx3y1},
 volume = {71},
 year = {2003}
 }
@@ -136,7 +136,7 @@ volume = {15549},
 year = {2009}
 }
 @article{Abdulkadiroglu.2011,
-author = {Abdulkadiroglu, Atila and S{\"{o}}nmez, Tayfun},
+author = {Abdulkadiroglu, Atila and S\"{o}nmez, Tayfun},
 journal = {Unpublished Manuscript},
 title = {{Matching Markets: Theory and Practice}},
 year = {2011}
@@ -194,7 +194,7 @@ journal = {RAND Journal of Economics},
 number = {3},
 pages = {738--761},
 title = {{Quantifying equilibrium network externalities in the ACH banking industry}},
-url = {http://www.scopus.com/inward/record.url?eid=2-s2.0-34248384433{\&}partnerID=40{\&}md5=d00136a5f1532a40595cbb0000a33a58},
+url = {http://www.scopus.com/inward/record.url?eid=2-s2.0-34248384433&partnerID=40&md5=d00136a5f1532a40595cbb0000a33a58},
 volume = {37},
 year = {2006}
 }
@@ -247,7 +247,7 @@ year = {2003}
 }
 @article{Adler.2014,
 abstract = {Characterizing uncertainty in the assessment of evidence is common practice when communicating science to users, a prominent example being the Intergovernmental Panel on Climate Change (IPCC) Assessment Reports (ARs). The IPCC guidance note is designed to assist authors in the assessment process by assuring consistent treatment of uncertainties across working groups (WGs). However, debate on this approach has surfaced among scholars on whether applying the guidance note indeed yields the desired consistent treatment of uncertainties thus facilitating effective communication of findings to users. The IPCC guidance note is therefore a paradigmatic case for reviewing concerns regarding treatment of uncertainties for policy. We reviewed published literature that outline disagreement or dissensus on the guidance note in the IPCC assessment process, structured as three distinct topics. First, whether the procedure is reliable and leads to robust results. Second, whether the broad scope of diverse problems, epistemic approaches, and user perspectives allow for consistent and appropriate application. Third, whether the guidance note is adequate for the purpose of communicating clear and relevant information to users. Overall, we find greater emphasis placed on problems arising from the procedure and purpose of the assessment, rather than the scope of application. Since a procedure needs to be appropriate for its purpose and scope, a way forward entails not only making deliberative processes more transparent to control biases. It also entails developing differentiated instruments to account for diversity and complexity of problems, approaches, and perspectives, treating sources of uncertainty as relevant information to users.},
-author = {Adler, Carolina E. and {Hirsch Hadorn}, Gertrude},
+author = {Adler, Carolina E. and Hirsch Hadorn, Gertrude},
 doi = {10.1002/wcc.297},
 isbn = {1757-7799},
 issn = {17577799},
@@ -311,7 +311,7 @@ author = {Aitchison, J and Silvey, S D},
 journal = {Biometrika},
 number = {1},
 pages = {131--140},
-title = {{{\{}T{\}}he {\{}G{\}}eneralization of {\{}P{\}}robit {\{}A{\}}nalysis to the {\{}C{\}}ase of {\{}M{\}}ultiple {\{}R{\}}esponses}},
+title = {{The Generalization of Probit Analysis to the Case of Multiple Responses}},
 volume = {44},
 year = {1957}
 }
@@ -319,7 +319,7 @@ year = {1957}
 author = {Aiyagarai, Rao S and Greenwood, Jeremy and Seshadri, Ananth},
 journal = {Jounal of Eonomic Theory},
 pages = {290--321},
-title = {{{\{}E{\}}fficient {\{}I{\}}nvestment in {\{}C{\}}hildren}},
+title = {{Efficient Investment in Children}},
 volume = {101},
 year = {2002}
 }
@@ -490,7 +490,7 @@ booktitle = {Handbook of Simulation},
 chapter = {9},
 editor = {Banks, Jerry},
 pages = {307--334},
-publisher = {John Wiley {\&} Sons, New York},
+publisher = {John Wiley \& Sons, New York},
 title = {{Simulation optimization}},
 year = {1998}
 }
@@ -505,14 +505,14 @@ volume = {65},
 year = {1998}
 }
 @article{Anger.2009,
-abstract = {Das Sozio-oekonomische Panel (SOEP) ist als multidisziplin{\"{a}}res Haushaltspanel, das Informationen zu allen Personen, die in einem Panel-Haushalt leben, erhebt und damit alle Altersjahrg{\"{a}}nge abdeckt, nach 25 Jahren Laufzeit auch zu einer Kohorten- Studie geworden. Der zunehmende Erfolg der Forschungsinfrastruktur-Einrichtung SOEP speist sich in erster Linie daraus, dass die Analysekraft von L{\"{a}}ngsschnittstudien mit jedem weiteren Erhebungsjahr zunimmt. Hinzu kommen im Falle des SOEP seit Beginn an eine lange Reihe von Innovationen bei der Erhebung, Datenaufbereitung und Nutzer-Service. Deswegen gilt es zu {\"{u}}berlegen, wie die wissenschaftliche Power des SOEP weiter gest{\"{a}}rkt werden kann. Nicht zuletzt auch, da es f{\"{u}}r neue, spezialisierte Panel-Studien (wie das Nationale Bildungspanel oder das DFG-gef{\"{o}}rderte Familienpanel PAIRFAM) eine Referenz und ggf. Verankerung der Hochrechnung darstellt. Zudem kann das SOEP k{\"{u}}nftig eine gr{\"{o}}{\ss}ere Rolle als „Kontroll-Stichprobe“ f{\"{u}}r Interventions-Studien spielen; etwa im Bereich der Kindheitsentwicklung. Auf diese neuen Rollen muss es vorbereitet sein. Die im SOEP in den letzten Jahren realisierten Erhebungsinnovationen wie z. B. die Inkorporation psychologischer Konzepte, physische Gesundheitsmessungen (Greifkraft), die Messung kognitiver F{\"{a}}higkeiten und die Erprobung von Verhaltens- Experimenten werden in anderen Panel-Studien aufgegriffen und auf eine gr{\"{o}}{\ss}ere Stichprobenbasis gestellt. Im UK wird mit „Understanding Society“ ein Haushaltspanel mit 40.000 Haushalten begonnen; in den Niederlanden wird mit MESS ein Haushaltspanel von {\"{u}}ber 5.000 Haushalten f{\"{u}}r innovative Messmethoden zur Verf{\"{u}}gung gestellt. Die Erhebungsinhalte des SOEP werden von den Forschungs- und Politikberatungs-Communities unver{\"{a}}ndert stark nachgefragt. In UK hat ein f{\"{u}}r „Understanding Society“ breit angelegter Konsultationsprozess keine grunds{\"{a}}tzlich neuen Befragungsinhalte zu Tage gef{\"{o}}rdert, die das SOEP nicht bereits enth{\"{a}}lt oder die f{\"{u}}r das SOEP ohnehin im Gespr{\"{a}}ch sind. Wichtiger als die „Entdeckung“ v{\"{o}}llig neuer Erhebungsinhalte ist das thematische wie zeitliche „Zuschneiden“ der Details von Befragungsinhalten auf (zugespitzte) neue (theoretische) Fragestellungen und dabei gleichzeitig bew{\"{a}}hrte sowie viel genutzte zentrale Befragungsinhalte und deren Befragungsrhythmen beizubehalten. Das „Ma{\ss}schneidern“ von Erhebungsinhalten wird in den n{\"{a}}chsten Jahren die eigentliche Herausforderung f{\"{u}}r Infrastruktur- Erhebungen wie die PSID, „Understanding Society“ und das SOEP sein. Bei den Erhebungsinhalten sollten die „R{\"{a}}nder“ des Lebenslaufs eine gr{\"{o}}{\ss}ere Rolle spielen, da diese von Haushalts-Panels besonders gut erfasst werden k{\"{o}}nnen. Diese Verbesserungen der Erhebungen beziehen sich einerseits auf die f{\"{o}}tale Phase von in das SOEP hineingeborenen Kindern und die (fr{\"{u}}he) Kindheit, andererseits auf die letzte Lebensphase und das Sterben. In der Mitte des Lebenslaufs werden verbesserte Fragen zum Einkommen, Sparen und Verm{\"{o}}gen sowie auch psychologische Konstrukte eine zentrale Rolle spielen, au{\ss}erdem gezielte Fragen (event triggered questionnaires) in Verbindung mit zentralen Lebensereignissen wie z. B. Eheschlie{\ss}ung, Scheidung, Eintritt in und Austritt aus Arbeitslosigkeit. Es wird die Etablierung einer SOEP-“Innovations-Stichprobe“ vorbereitet, um theoriegeleitete Forschungsfragen gezielter unterst{\"{u}}tzen zu k{\"{o}}nnen. Dazu wird es auch notwendig sein, neue Messkonzepte zu erproben (z. B. die Erhebung von Biomarkern, qualitative Erhebungen, aber auch Experimente und gezielte Interventionsstudien). Um die Power von L{\"{a}}ngsschnittdaten von Anfang an f{\"{u}}r die Innovations-Stichprobe ausnutzen zu k{\"{o}}nnen, ist geplant, zwei kleinere Teilstichproben des SOEP, die seit 1998 bzw. 2006 laufen (Subsamples E und H), in die Innovationsstichprobe zu {\"{u}}berf{\"{u}}hren. Um die statistische Power langlaufender L{\"{a}}ngsschnittdaten entscheidend zu verbessern, sch{\"{a}}tzen wir eine Mindestfallzahl von etwa 500 Personen pro Geburtsund Alterskohorte f{\"{u}}r ausreichend ein. Um dieses Ziel zu erreichen, muss die Fallzahl des SOEP-Standard-Samples erh{\"{o}}ht werden. Als „Nebeneffekt“ werden dadurch wesentlich bessere Analysen f{\"{u}}r relativ kleine Gruppen in der Bev{\"{o}}lkerung m{\"{o}}glich; etwa f{\"{u}}r allein Erziehende oder bestimme Immigrantengruppen. Au{\ss}erdem verbessern sich als weiterer „Nebeneffekt“ auch regionale Analysem{\"{o}}glichkeiten, z. B. f{\"{u}}r die meisten Bundesl{\"{a}}nder und in gro{\ss}en Bundesl{\"{a}}ndern bis hin zu Regierungsbezirken (oder {\"{a}}hnlich abgegrenzten regionalen Einheiten). In letzter Zeit wird immer deutlicher, welche gro{\ss}e Bedeutung das SOEP als „Referenz-Datensatz“ f{\"{u}}r spezialisierte und vom SOEP v{\"{o}}llig unabh{\"{a}}ngige Erhebungen hat (neben Beobachtungsstudien, wie etwa Zwillings-Studien, auch Labor- und Interventions-Studien). Zur Unterst{\"{u}}tzung dieser Funktion ist eine neue Art von Service, der in Deutschland bislang nicht vorgehalten wird, notwendig (Beratung von Spezial-Erhebungen; ggf. Datenaufbereitung von l{\"{a}}ngsschnittlichen Spezial-Erhebungen), der auch in ein Datenservicezentrum eingebracht werden k{\"{o}}nnte. After 25 years as a multidisciplinary household panel containing information on all individuals residing in panel households and thus covering all age cohorts, the German Socio-Economic Panel (SOEP) has become a true cohort study as well. The increasing success of the SOEP research infrastructure comes above all from the increasing analytical power that longitudinal studies attain with each successive survey year. In the case of SOEP, a long series of innovations in surveying, data preparation, and user service have also played a major role. For this reason, it is important to consider how the scientific capacity of SOEP can be further enhanced— not least of all since the SOEP can form a key point of reference (or “anchor”) for new, specialized panel studies (such as the National Educational Panel and the family panel PAIRFAM, funded by the German Research Foundation). Furthermore SOEP can become a kind of “control sample” for intervention studies, for example, in the field of child development. The SOEP survey and its governance structures must be prepared for these new tasks. The numerous innovations introduced into SOEP in recent years—questions dealing with psychological concepts, physical health measures (grip strength), measures of cognitive capabilities, and behavioral experiments—have been incorporated into other panel studies as well, and thus provided with a larger sample base. In the UK, the “Understanding Society“ household panel study was launched with 40,000 households; in the Netherlands, the MESS household panel study of over 5,000 households offered a new basis for testing innovative measurement methods. The results of the SOEP survey are in continuing high demand in the research and policy advisory community. From our point of view, the large-scale consultation process conducted to define the content of the UK survey “Understanding Society“ failed to identify any fundamentally new survey content that the SOEP either did not already contain or that was not already being discussed for the SOEP. More important than “discovering” entirely new survey areas is “tailoring” the details of existing survey content to address new, more specific (theoretical) questions, and thus maintaining proven and widely used elements of survey content. The “tailoring” of survey content will be the real challenge facing infrastructure surveys like PSID, “Understanding Society,” and the SOEP in the coming years. In the future, the “margins” of the life course should play a stronger role in survey content, since household panels are able to provide outstanding data of these life phases. The SOEP, and other household panel surveys, can be improved, on the one hand, by including the fetal phase of life and early childhood for children born into the panel, and on the other, by including late life and death. In the middle of the life course, improved questions on income, savings, and wealth as well as psychological constructs will play a central role, as will specific questions (in “eventtriggered” questionnaires) on central life occurrences such as marriage, divorce, and entry into and exit from unemployment. Current plans for SOEP foresee the addition of an “Innovation Sample” that will make it possible to better address theory-based research questions required for testing new measurement concepts (e.g., the surveying of biomarkers, qualitative surveys, but also experiments and targeted intervention studies). In order to exploit the power of longitudinal data from the outset, we plan to incorporate two smaller SOEP subsamples that have been running since 1998 and 2006 (Subsamples E and H, respectively) into the Innovation Sample. In order to decisively improve the statistical power of long-term longitudinal data, we believe that a minimum case number of about 500 persons per birth and age cohort is required. In order to reach this goal, the case number in the SOEP standard samples needs to be increased. A positive side-effect of this enlargement would be a significantly improved potential for analyses of relatively small groups within the population: for example, lone parents or specific immigrant groups. Another positive side-effect would be an improved potential for regional analyses: for example, for the majority of federal states. In recent times, the importance of SOEP as a “reference dataset” for specialized surveys which are independent from SOEP (observational studies such as twin studies, and laboratory and intervention studies) has become strikingly evident. To enhance this important function, new types of service are needed (advice on special surveys, possibly also data preparation for special surveys), which could become part of a Data Service Center.},
+abstract = {Das Sozio-oekonomische Panel (SOEP) ist als multidisziplin\"{a}res Haushaltspanel, das Informationen zu allen Personen, die in einem Panel-Haushalt leben, erhebt und damit alle Altersjahrg\"{a}nge abdeckt, nach 25 Jahren Laufzeit auch zu einer Kohorten- Studie geworden. Der zunehmende Erfolg der Forschungsinfrastruktur-Einrichtung SOEP speist sich in erster Linie daraus, dass die Analysekraft von L\"{a}ngsschnittstudien mit jedem weiteren Erhebungsjahr zunimmt. Hinzu kommen im Falle des SOEP seit Beginn an eine lange Reihe von Innovationen bei der Erhebung, Datenaufbereitung und Nutzer-Service. Deswegen gilt es zu \"{u}berlegen, wie die wissenschaftliche Power des SOEP weiter gest\"{a}rkt werden kann. Nicht zuletzt auch, da es f\"{u}r neue, spezialisierte Panel-Studien (wie das Nationale Bildungspanel oder das DFG-gef\"{o}rderte Familienpanel PAIRFAM) eine Referenz und ggf. Verankerung der Hochrechnung darstellt. Zudem kann das SOEP k\"{u}nftig eine gr\"{o}{\ss}ere Rolle als „Kontroll-Stichprobe“ f\"{u}r Interventions-Studien spielen; etwa im Bereich der Kindheitsentwicklung. Auf diese neuen Rollen muss es vorbereitet sein. Die im SOEP in den letzten Jahren realisierten Erhebungsinnovationen wie z. B. die Inkorporation psychologischer Konzepte, physische Gesundheitsmessungen (Greifkraft), die Messung kognitiver F\"{a}higkeiten und die Erprobung von Verhaltens- Experimenten werden in anderen Panel-Studien aufgegriffen und auf eine gr\"{o}{\ss}ere Stichprobenbasis gestellt. Im UK wird mit „Understanding Society“ ein Haushaltspanel mit 40.000 Haushalten begonnen; in den Niederlanden wird mit MESS ein Haushaltspanel von \"{u}ber 5.000 Haushalten f\"{u}r innovative Messmethoden zur Verf\"{u}gung gestellt. Die Erhebungsinhalte des SOEP werden von den Forschungs- und Politikberatungs-Communities unver\"{a}ndert stark nachgefragt. In UK hat ein f\"{u}r „Understanding Society“ breit angelegter Konsultationsprozess keine grunds\"{a}tzlich neuen Befragungsinhalte zu Tage gef\"{o}rdert, die das SOEP nicht bereits enth\"{a}lt oder die f\"{u}r das SOEP ohnehin im Gespr\"{a}ch sind. Wichtiger als die „Entdeckung“ v\"{o}llig neuer Erhebungsinhalte ist das thematische wie zeitliche „Zuschneiden“ der Details von Befragungsinhalten auf (zugespitzte) neue (theoretische) Fragestellungen und dabei gleichzeitig bew\"{a}hrte sowie viel genutzte zentrale Befragungsinhalte und deren Befragungsrhythmen beizubehalten. Das „Ma{\ss}schneidern“ von Erhebungsinhalten wird in den n\"{a}chsten Jahren die eigentliche Herausforderung f\"{u}r Infrastruktur- Erhebungen wie die PSID, „Understanding Society“ und das SOEP sein. Bei den Erhebungsinhalten sollten die „R\"{a}nder“ des Lebenslaufs eine gr\"{o}{\ss}ere Rolle spielen, da diese von Haushalts-Panels besonders gut erfasst werden k\"{o}nnen. Diese Verbesserungen der Erhebungen beziehen sich einerseits auf die f\"{o}tale Phase von in das SOEP hineingeborenen Kindern und die (fr\"{u}he) Kindheit, andererseits auf die letzte Lebensphase und das Sterben. In der Mitte des Lebenslaufs werden verbesserte Fragen zum Einkommen, Sparen und Verm\"{o}gen sowie auch psychologische Konstrukte eine zentrale Rolle spielen, au{\ss}erdem gezielte Fragen (event triggered questionnaires) in Verbindung mit zentralen Lebensereignissen wie z. B. Eheschlie{\ss}ung, Scheidung, Eintritt in und Austritt aus Arbeitslosigkeit. Es wird die Etablierung einer SOEP-“Innovations-Stichprobe“ vorbereitet, um theoriegeleitete Forschungsfragen gezielter unterst\"{u}tzen zu k\"{o}nnen. Dazu wird es auch notwendig sein, neue Messkonzepte zu erproben (z. B. die Erhebung von Biomarkern, qualitative Erhebungen, aber auch Experimente und gezielte Interventionsstudien). Um die Power von L\"{a}ngsschnittdaten von Anfang an f\"{u}r die Innovations-Stichprobe ausnutzen zu k\"{o}nnen, ist geplant, zwei kleinere Teilstichproben des SOEP, die seit 1998 bzw. 2006 laufen (Subsamples E und H), in die Innovationsstichprobe zu \"{u}berf\"{u}hren. Um die statistische Power langlaufender L\"{a}ngsschnittdaten entscheidend zu verbessern, sch\"{a}tzen wir eine Mindestfallzahl von etwa 500 Personen pro Geburtsund Alterskohorte f\"{u}r ausreichend ein. Um dieses Ziel zu erreichen, muss die Fallzahl des SOEP-Standard-Samples erh\"{o}ht werden. Als „Nebeneffekt“ werden dadurch wesentlich bessere Analysen f\"{u}r relativ kleine Gruppen in der Bev\"{o}lkerung m\"{o}glich; etwa f\"{u}r allein Erziehende oder bestimme Immigrantengruppen. Au{\ss}erdem verbessern sich als weiterer „Nebeneffekt“ auch regionale Analysem\"{o}glichkeiten, z. B. f\"{u}r die meisten Bundesl\"{a}nder und in gro{\ss}en Bundesl\"{a}ndern bis hin zu Regierungsbezirken (oder \"{a}hnlich abgegrenzten regionalen Einheiten). In letzter Zeit wird immer deutlicher, welche gro{\ss}e Bedeutung das SOEP als „Referenz-Datensatz“ f\"{u}r spezialisierte und vom SOEP v\"{o}llig unabh\"{a}ngige Erhebungen hat (neben Beobachtungsstudien, wie etwa Zwillings-Studien, auch Labor- und Interventions-Studien). Zur Unterst\"{u}tzung dieser Funktion ist eine neue Art von Service, der in Deutschland bislang nicht vorgehalten wird, notwendig (Beratung von Spezial-Erhebungen; ggf. Datenaufbereitung von l\"{a}ngsschnittlichen Spezial-Erhebungen), der auch in ein Datenservicezentrum eingebracht werden k\"{o}nnte. After 25 years as a multidisciplinary household panel containing information on all individuals residing in panel households and thus covering all age cohorts, the German Socio-Economic Panel (SOEP) has become a true cohort study as well. The increasing success of the SOEP research infrastructure comes above all from the increasing analytical power that longitudinal studies attain with each successive survey year. In the case of SOEP, a long series of innovations in surveying, data preparation, and user service have also played a major role. For this reason, it is important to consider how the scientific capacity of SOEP can be further enhanced— not least of all since the SOEP can form a key point of reference (or “anchor”) for new, specialized panel studies (such as the National Educational Panel and the family panel PAIRFAM, funded by the German Research Foundation). Furthermore SOEP can become a kind of “control sample” for intervention studies, for example, in the field of child development. The SOEP survey and its governance structures must be prepared for these new tasks. The numerous innovations introduced into SOEP in recent years—questions dealing with psychological concepts, physical health measures (grip strength), measures of cognitive capabilities, and behavioral experiments—have been incorporated into other panel studies as well, and thus provided with a larger sample base. In the UK, the “Understanding Society“ household panel study was launched with 40,000 households; in the Netherlands, the MESS household panel study of over 5,000 households offered a new basis for testing innovative measurement methods. The results of the SOEP survey are in continuing high demand in the research and policy advisory community. From our point of view, the large-scale consultation process conducted to define the content of the UK survey “Understanding Society“ failed to identify any fundamentally new survey content that the SOEP either did not already contain or that was not already being discussed for the SOEP. More important than “discovering” entirely new survey areas is “tailoring” the details of existing survey content to address new, more specific (theoretical) questions, and thus maintaining proven and widely used elements of survey content. The “tailoring” of survey content will be the real challenge facing infrastructure surveys like PSID, “Understanding Society,” and the SOEP in the coming years. In the future, the “margins” of the life course should play a stronger role in survey content, since household panels are able to provide outstanding data of these life phases. The SOEP, and other household panel surveys, can be improved, on the one hand, by including the fetal phase of life and early childhood for children born into the panel, and on the other, by including late life and death. In the middle of the life course, improved questions on income, savings, and wealth as well as psychological constructs will play a central role, as will specific questions (in “eventtriggered” questionnaires) on central life occurrences such as marriage, divorce, and entry into and exit from unemployment. Current plans for SOEP foresee the addition of an “Innovation Sample” that will make it possible to better address theory-based research questions required for testing new measurement concepts (e.g., the surveying of biomarkers, qualitative surveys, but also experiments and targeted intervention studies). In order to exploit the power of longitudinal data from the outset, we plan to incorporate two smaller SOEP subsamples that have been running since 1998 and 2006 (Subsamples E and H, respectively) into the Innovation Sample. In order to decisively improve the statistical power of long-term longitudinal data, we believe that a minimum case number of about 500 persons per birth and age cohort is required. In order to reach this goal, the case number in the SOEP standard samples needs to be increased. A positive side-effect of this enlargement would be a significantly improved potential for analyses of relatively small groups within the population: for example, lone parents or specific immigrant groups. Another positive side-effect would be an improved potential for regional analyses: for example, for the majority of federal states. In recent times, the importance of SOEP as a “reference dataset” for specialized surveys which are independent from SOEP (observational studies such as twin studies, and laboratory and intervention studies) has become strikingly evident. To enhance this important function, new types of service are needed (advice on special surveys, possibly also data preparation for special surveys), which could become part of a Data Service Center.},
 author = {Anger, S and Frick, F and Goebel, J and Grabka, M and Groh-Samberg, O and Haas, H and Holst, E and Krause, P and Kroh, M and Lohmann, H and Schupp, J and Sieber, I and Siedler, T and Schmitt, C and Spie{\ss}, C K and Tucci, I and Wagner, G G},
 isbn = {155},
 journal = {SOEPpapers},
 keywords = {German Socio-Economic Panel Study,Household Panels,SOEP},
 pages = {No. 155},
 title = {{Developing SOEPsurvey and SOEPservice: The (Near) Future of the German Socio-Economic Panel Study (SOEP)}},
-url = {https://ideas.repec.org/cgi-bin/htsearch?cmd=Search!{\&}db=01/01/1990{\&}de={\&}dt=range{\&}fmt=long{\&}m=all{\&}np=24{\&}ps=50{\&}q=(saving++{\%}7C+micro-saving+{\%}7Cmicrosaving+{\%}7C+Aflatoun+{\%}7C+YouthSafe+)+++(“randomized+control*+trial”+{\%}7C++“randomised+cont},
+url = {https://ideas.repec.org/cgi-bin/htsearch?cmd=Search!&db=01/01/1990&de=&dt=range&fmt=long&m=all&np=24&ps=50&q=(saving++{\%}7C+micro-saving+{\%}7Cmicrosaving+{\%}7C+Aflatoun+{\%}7C+YouthSafe+)+++(“randomized+control*+trial”+{\%}7C++“randomised+cont},
 year = {2009}
 }
 @article{Anger.2006,
@@ -572,7 +572,7 @@ author = {Angrist, Joshua D},
 doi = {10.1198/07350010152472571},
 isbn = {0735-0015},
 issn = {0735-0015},
-journal = {Journal of Business {\&} Economic Statistics},
+journal = {Journal of Business \& Economic Statistics},
 keywords = {Instrumental variables,Labor supply,Sample selection,Semiparametric methods,Tobit},
 number = {1},
 pages = {2--28},
@@ -606,7 +606,7 @@ year = {1990}
 }
 @article{Angrist.2010h,
 abstract = {Since Edward Leamer's memorable 1983 paper, "Let's Take the Con out of Econometrics," empirical microeconomics has experienced a credibility revolution. While Leamer's suggested remedy, sensitivity analysis, has played a role in this, we argue that the primary engine driving improvement has been a focus on the quality of empirical research designs. The advantages of a good research design are perhaps most easily apparent in research using random assignment. We begin with an overview of Leamer's 1983 critique and his proposed remedies. We then turn to the key factors we see contributing to improved empirical work, including the availability of more and better data, along with advances in theoretical econometric understanding, but especially the fact that research design has moved front and center in much of empirical micro. We offer a brief digression into macroeconomics and industrial organization, where progress -- by our lights -- is less dramatic, although there is work in both fields that we find encouraging. Finally, we discuss the view that the design pendulum has swung too far. Critics of design-driven studies argue that in pursuit of clean and credible research designs, researchers seek good answers instead of good questions. We briefly respond to this concern, which worries us little.},
-author = {Angrist, Joshua D. and Pischke, J{\"{o}}rn-Steffen},
+author = {Angrist, Joshua D. and Pischke, J\"{o}rn-Steffen},
 doi = {10.1257/jep.24.2.3},
 isbn = {0895-3309},
 issn = {0895-3309},
@@ -621,7 +621,7 @@ year = {2010}
 }
 @article{Angrist.2010,
 abstract = {Since Edward Leamer's memorable 1983 paper, "Let's Take the Con out of Econometrics," empirical microeconomics has experienced a credibility revolution. While Leamer's suggested remedy, sensitivity analysis, has played a role in this, we argue that the primary engine driving improvement has been a focus on the quality of empirical research designs. The advantages of a good research design are perhaps most easily apparent in research using random assignment. We begin with an overview of Leamer's 1983 critique and his proposed remedies. We then turn to the key factors we see contributing to improved empirical work, including the availability of more and better data, along with advances in theoretical econometric understanding, but especially the fact that research design has moved front and center in much of empirical micro. We offer a brief digression into macroeconomics and industrial organization, where progress -- by our lights -- is less dramatic, although there is work in both fields that we find encouraging. Finally, we discuss the view that the design pendulum has swung too far. Critics of design-driven studies argue that in pursuit of clean and credible research designs, researchers seek good answers instead of good questions. We briefly respond to this concern, which worries us little.},
-author = {Angrist, Joshua D. and Pischke, J{\"{o}}rn-Steffen},
+author = {Angrist, Joshua D. and Pischke, J\"{o}rn-Steffen},
 doi = {10.1257/jep.24.2.3},
 isbn = {0895-3309},
 issn = {0895-3309},
@@ -765,7 +765,7 @@ year = {1999}
 }
 @article{Asparouhov.2010,
 author = {Asparouhov, Tihomir and Muth{\'{e}}n, Bengt},
-journal = {Los Angeles: Muth{\'{e}}n {\&} Muth{\'{e}}n},
+journal = {Los Angeles: Muth{\'{e}}n \& Muth{\'{e}}n},
 pages = {1--38},
 title = {{Bayesian analysis using Mplus: Technical implementation}},
 year = {2010}
@@ -864,7 +864,7 @@ doi = {tech. report CMU-RI-TR-01-25},
 journal = {Carnegie Mellon Research Showcase},
 pages = {948 -- 957},
 title = {{Solving Uncertain Markov Decision Processes}},
-url = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.57.8550{\&}rep=rep1{\&}type=pdf{\%}5Cnhttp://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.57.8550},
+url = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.57.8550&rep=rep1&type=pdf{\%}5Cnhttp://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.57.8550},
 year = {2001}
 }
 @article{Bagnoli.2005,
@@ -896,7 +896,7 @@ doi = {10.1198/jbes.2009.07264},
 eprint = {arXiv:1011.1669v3},
 isbn = {9788578110796},
 issn = {0735-0015},
-journal = {Journal of Business {\&} Economic Statistics},
+journal = {Journal of Business \& Economic Statistics},
 keywords = {discrete choice,stock analyst recommendation,structural estimation},
 number = {July 2013},
 pages = {469--482},
@@ -938,7 +938,7 @@ volume = {21},
 year = {2003}
 }
 @book{Banks.2009,
-abstract = {For Junior {\&} Senior level simulation courses in engineering, business, or computer science.This text provides a basic treatment of discrete-event simulation, including the proper collection and analysis of data, the use of analytic techniques, verification and validation of models, and designing simulation experiments. It offers an up-to-date treatment of simulation of manufacturing and material handling systems, computer systems, and computer networks.Students and instructors will find a variety of resources at the associated website, www.bcnn.net , including simulation source code for download, additional exercises and solutions, web links and errata.},
+abstract = {For Junior \& Senior level simulation courses in engineering, business, or computer science.This text provides a basic treatment of discrete-event simulation, including the proper collection and analysis of data, the use of analytic techniques, verification and validation of models, and designing simulation experiments. It offers an up-to-date treatment of simulation of manufacturing and material handling systems, computer systems, and computer networks.Students and instructors will find a variety of resources at the associated website, www.bcnn.net , including simulation source code for download, additional exercises and solutions, web links and errata.},
 author = {Banks, Jerry and II, John S Carson and Nelson, Barry L and Nicol, David M},
 publisher = {Prentice Hall},
 title = {{Discrete-Event System Simulation}},
@@ -1098,7 +1098,7 @@ year = {1974}
 }
 @article{Behncke.2009,
 abstract = {We evaluate a randomized experiment of a statistical support system developed to assist caseworkers in Swiss employment offices in choosing appropriate active labour market programmes for their unemployed clients. This statistical support system predicted the labour market outcome for each programme and thereby suggested an 'optimal' labour market programme for each unemployed person. The support system was piloted in several employment offices. In those pilot offices, half of the caseworkers used the system and the other half acted as control group. The allocation of the caseworkers to treatment and control group was random. The experiment was designed such that caseworkers retained full discretion about the choice of active labour market programmes, and the evaluation results showed that caseworkers largely ignored the statistical support system. This indicates that stronger incentives are needed for caseworkers to comply with statistical profiling and targeting systems.},
-author = {Behncke, S and Fr{\"{o}}lich, M and Lechner, M},
+author = {Behncke, S and Fr\"{o}lich, M and Lechner, M},
 doi = {http://dx.doi.org/10.2139/ssrn.1021673},
 journal = {Swiss Journal of Economics and Statistics},
 number = {3},
@@ -1109,7 +1109,7 @@ year = {2009}
 }
 @article{Behncke.2007a,
 abstract = {We evaluate a randomized experiment of a statistical support system developed to assist caseworkers in Swiss employment offices in choosing appropriate active labour market programmes for their unemployed clients. This statistical support system predicted the labour market outcome for each programme and thereby suggested an 'optimal' labour market programme for each unemployed person. The support system was piloted in several employment offices. In those pilot offices, half of the caseworkers used the system and the other half acted as control group. The allocation of the caseworkers to treatment and control group was random. The experiment was designed such that caseworkers retained full discretion about the choice of active labour market programmes, and the evaluation results showed that caseworkers largely ignored the statistical support system. This indicates that stronger incentives are needed for caseworkers to comply with statistical profiling and targeting systems.},
-author = {Behncke, S and Fr{\"{o}}lich, M and Lechner, M},
+author = {Behncke, S and Fr\"{o}lich, M and Lechner, M},
 doi = {http://dx.doi.org/10.2139/ssrn.1021673},
 journal = {Swiss Journal of Economics and Statistics},
 number = {3},
@@ -1120,9 +1120,9 @@ year = {2009}
 }
 @techreport{Behncke.2007b,
 address = {St. Gallen, Switzerland},
-author = {Behncke, Stefanie and Fr{\"{o}}lich, Markus and Lechner, MIchael},
-booktitle = {Schweizerisches Institut f{\"{u}}r Aussenwirtschaft und Angewandte Wirtschaftsforschung},
-institution = {Schweizerisches Institut f{\"{u}}r Aussenwirtschaft und Angewandte Wirtschaftsforschung},
+author = {Behncke, Stefanie and Fr\"{o}lich, Markus and Lechner, MIchael},
+booktitle = {Schweizerisches Institut f\"{u}r Aussenwirtschaft und Angewandte Wirtschaftsforschung},
+institution = {Schweizerisches Institut f\"{u}r Aussenwirtschaft und Angewandte Wirtschaftsforschung},
 pages = {1--179},
 title = {{Abschlussbericht zum Pilotprojekt Statistisch assistierte Programmselektion (SAPS)}},
 year = {2007}
@@ -1131,7 +1131,7 @@ year = {2007}
 abstract = {preference models consensus parental preference models nonconcensus models of household behavior impact of household time allocation human capital investment wages other economic outcomes differences in within-household allocation male vs. female prime-age vs. elderly high- vs. low birth order regaulation of allocation by endowments preferences human resource investment prices household resource level marriage market labor market opportunities importance of within.household allocations critical role for household in human capital investment (inferior results due to noncooperative bargaining) effect of intrahousehold distribution on inequality efficacy of micro- and macroeconomic targeted programs allocations efficiency efficacy equity$\backslash$ne},
 address = {Amsterdam, Netherlands},
 author = {Behrman, Jere R},
-booktitle = {{\{}H{\}}andbook of {\{}P{\}}opulation and {\{}F{\}}amily {\{}E{\}}conomics},
+booktitle = {Handbook of Population and Family Economics},
 editor = {Rosenzweig, Mark R and Stark, Oded},
 pages = {125--187},
 publisher = {North-Holland Publishing Company},
@@ -1140,7 +1140,7 @@ volume = {1A},
 year = {1997}
 }
 @book{Behrman.1997b,
-address = {Ann{\$}{\~{}}{\$}Arbor, MI},
+address = {Ann Arbor, MI},
 editor = {Behrman, Jere R and Nevzer, Stacey},
 publisher = {University of Michigan Press},
 title = {{The Social Benefits of Education}},
@@ -1167,8 +1167,8 @@ issn = {00346535},
 journal = {The Review of Economics and Statistics},
 number = {1},
 pages = {144},
-title = {{Intergenerational Earnings Mobility in the United States: Some Estimates and a Test of Becker's Intergenerational Endowments {\{}M{\}}odel}},
-url = {http://proxy.uchicago.edu/login?url=http://search.ebscohost.com/login.aspx?direct=true{\&}db=edsjsr{\&}AN=edsjsr.10.2307.1928446{\&}site=eds-live{\&}scope=site},
+title = {{Intergenerational Earnings Mobility in the United States: Some Estimates and a Test of Becker's Intergenerational Endowments Model}},
+url = {http://proxy.uchicago.edu/login?url=http://search.ebscohost.com/login.aspx?direct=true&db=edsjsr&AN=edsjsr.10.2307.1928446&site=eds-live&scope=site},
 volume = {67},
 year = {1985}
 }
@@ -1303,14 +1303,14 @@ isbn = {978-3-642-57615-7},
 pages = {59--84},
 publisher = {Physica Verlag},
 title = {{Evaluating profiling as a means of allocating government services}},
-url = {http://books.google.com/books?hl=en{\&}lr={\&}id=Ngxk7pe1sB4C{\&}oi=fnd{\&}pg=PA59{\&}dq=Evaluating+Profiling+as+a+Means+of+Allocating+Government+Services{\&}ots=dwhCV1lIvx{\&}sig=70XUvtA1EwZzvLYZbgDlqpsOE80},
+url = {http://books.google.com/books?hl=en&lr=&id=Ngxk7pe1sB4C&oi=fnd&pg=PA59&dq=Evaluating+Profiling+as+a+Means+of+Allocating+Government+Services&ots=dwhCV1lIvx&sig=70XUvtA1EwZzvLYZbgDlqpsOE80},
 year = {2001}
 }
 @incollection{Bergstrom.1997,
 abstract = {household technology and utility possibility frontier household prodction function specialisation comparative advantage returns to scale facctor substitution human capital assortive mating household public goods household utility possibility frontier transferabel utility family decision making unitary theories transferable utility pluralistic theories proportional sharing rules cooperative Nash bargaining methods},
 address = {Amsterdam, Netherlands},
 author = {Bergstrom, Theodore C},
-booktitle = {{\{}H{\}}andbook of {\{}P{\}}opulation and {\{}F{\}}amily {\{}E{\}}conomics},
+booktitle = {Handbook of Population and Family Economics},
 editor = {Rosenzweig, Mark R and Stark, Oded},
 pages = {21--79},
 publisher = {North-Holland Publishing Company},
@@ -1556,7 +1556,7 @@ year = {2007}
 }
 @article{Bishop.2011,
 author = {Bishop, K C and Murphy, A D},
-journal = {American Economic Review: Papers {\&} Proceedings},
+journal = {American Economic Review: Papers \& Proceedings},
 number = {3},
 pages = {625--629},
 title = {{Estimating the Willingness to Pay to Avoid Violent Crime: A Dynamic Approach}},
@@ -1565,12 +1565,12 @@ year = {2011}
 }
 @article{Bishop.2016,
 author = {Bishop, Kelly C and Murphy, Alvin},
-journal = {R{\&}R at Review of Economics and Statistics},
+journal = {R&R at Review of Economics and Statistics},
 title = {{Valuing Time-Varying Attributes using the Hedonic Model: When is a Dynamic Approach Necessary?}},
 year = {2016}
 }
 @article{Bjorklund.1988,
-author = {Bj{\"{o}}rklund, Anders},
+author = {Bj\"{o}rklund, Anders},
 journal = {The Journal of Human Resources},
 number = {2},
 pages = {267--277},
@@ -1579,47 +1579,47 @@ volume = {23},
 year = {1988}
 }
 @article{Bjorklund.1993,
-author = {Bj{\"{o}}rklund, Anders},
+author = {Bj\"{o}rklund, Anders},
 journal = {Review of Income and Wealth},
 number = {5},
 pages = {1009--1018},
-title = {{{\{}A{\}} {\{}C{\}}omparisons {\{}B{\}}etween {\{}A{\}}ctual {\{}D{\}}istributions of {\{}A{\}}nnual and {\{}L{\}}ifetime {\{}I{\}}ncome: {\{}S{\}}weden 1951-1989}},
+title = {{A Comparisons Between Actual Distributions of Annual and Lifetime Income: Sweden 1951-1989}},
 volume = {39},
 year = {1993}
 }
 @article{Bjorklund.2002,
-author = {Bj{\"{o}}rklund, Anders and Erikson, Tor and J{\"{a}}ntti, Markus and Raaum, Oddbj{\"{o}}rn and {\"{O}}sterbacka, Eva},
+author = {Bj\"{o}rklund, Anders and Erikson, Tor and J\"{a}ntti, Markus and Raaum, Oddbj\"{o}rn and \"{O}sterbacka, Eva},
 journal = {Journal of Population Economics},
 number = {4},
 pages = {757--772},
-title = {{{\{}B{\}}rother {\{}C{\}}orrelations in {\{}E{\}}arnings in {\{}D{\}}enmark, {\{}F{\}}inland, {\{}N{\}}orway, and {\{}S{\}}weden {\{}C{\}}ompared to the {\{}U{\}}nited {\{}S{\}}tates}},
+title = {{Brother Correlations in Earnings in Denmark, Finland, Norway, and Sweden Compared to the United States}},
 volume = {15},
 year = {2002}
 }
 @article{Bjorklund.1997,
-author = {Bj{\"{o}}rklund, Anders and J{\"{a}}ntti, Markus},
+author = {Bj\"{o}rklund, Anders and J\"{a}ntti, Markus},
 journal = {American Economic Review},
 number = {5},
 pages = {1009--1018},
-title = {{{\{}I{\}}ntergenerational {\{}I{\}}ncome {\{}M{\}}obility in {\{}S{\}}weden {\{}C{\}}ompared to the {\{}U{\}}nited {\{}S{\}}tates}},
+title = {{Intergenerational Income Mobility in Sweden Compared to the United States}},
 volume = {87},
 year = {1997}
 }
 @article{Bjorklund.2007,
-author = {Bj{\"{o}}rklund, Anders and J{\"{a}}ntti, Markus and Solon, Gary},
+author = {Bj\"{o}rklund, Anders and J\"{a}ntti, Markus and Solon, Gary},
 journal = {NBER Working Paper},
-title = {{{\{}N{\}}ature and {\{}N{\}}urture in the {\{}I{\}}ntergenerational {\{}T{\}}ransmission of {\{}S{\}}ocioeconomic {\{}S{\}}tatus: {\{}E{\}}vidence from {\{}S{\}}wedish {\{}C{\}}hildren and {\{}T{\}}heir {\{}B{\}}iological and {\{}R{\}}earing {\{}P{\}}arents}},
+title = {{Nature and Nurture in the Intergenerational Transmission of Socioeconomic Status: Evidence from Swedish Children and Their Biological and Rearing Parents}},
 volume = {12985},
 year = {2007}
 }
 @article{Bjorklund.2008,
-author = {Bj{\"{o}}rklund, Anders and Lindahl, Lena and Lindquist, Matthew},
+author = {Bj\"{o}rklund, Anders and Lindahl, Lena and Lindquist, Matthew},
 journal = {Unpublished Manuscript},
-title = {{{\{}W{\}}hat {\{}M{\}}ore {\{}T{\}}han {\{}P{\}}arental {\{}I{\}}ncome? {\{}A{\}}n exploration of what {\{}S{\}}wedish siblings get from their parents}},
+title = {{What More Than Parental Income? An exploration of what Swedish siblings get from their parents}},
 year = {2008}
 }
 @article{Bjorklund.1987,
-author = {Bj{\"{o}}rklund, Anders and Moffitt, Robert},
+author = {Bj\"{o}rklund, Anders and Moffitt, Robert},
 journal = {The Review of Economics and Statistics},
 number = {1},
 pages = {42--49},
@@ -1628,7 +1628,7 @@ volume = {69},
 year = {1987}
 }
 @incollection{Bjorklund.1996,
-author = {Bj{\"{o}}rklund, Anders and Regner, Hakan},
+author = {Bj\"{o}rklund, Anders and Regner, Hakan},
 booktitle = {International Handbook of Labour Market Policy and Evaluation},
 publisher = {Cheltenham, Edward Elgar},
 title = {{Experimental Evaluation of European Labour Market Policy}},
@@ -1644,14 +1644,14 @@ year = {1981}
 @article{Black.2008,
 author = {Black, Sandra E and Devereux, Paul J and Salvanes, Kjell G},
 journal = {IZA Discussion Paper},
-title = {{{\{}L{\}}ike {\{}F{\}}ather, {\{}L{\}}ike {\{}S{\}}on? {\{}A{\}} {\{}N{\}}ote on the {\{}I{\}}ntergenerational {\{}T{\}}ransmission of {\{}I{\}}{\{}Q{\}} {\{}S{\}}cores}},
+title = {{Like Father, Like Son? A Note on the Intergenerational Transmission of IQ Scores}},
 volume = {No. 3651},
 year = {2008}
 }
 @article{Bladen.2005,
 author = {Bladen, Jo},
 journal = {Unpublished Manuscript},
-title = {{{\{}I{\}}nternational {\{}E{\}}vidence on {\{}I{\}}ntergenerational {\{}M{\}}obility}},
+title = {{International Evidence on Intergenerational Mobility}},
 year = {2005}
 }
 @article{Blanden.2007,
@@ -1659,14 +1659,14 @@ author = {Bladen, Jo and Gregg, Paul and Macmillan, Lindsey},
 journal = {The Economic Journal},
 number = {519},
 pages = {C43----C60},
-title = {{{\{}A{\}}ccounting for {\{}I{\}}ntergenerational {\{}I{\}}ncome {\{}P{\}}ersistence: {\{}N{\}}on-cognitive {\{}S{\}}kills, {\{}A{\}}bility and {\{}E{\}}ducation}},
+title = {{Accounting for Intergenerational Income Persistence: Non-cognitive Skills, Ability and Education}},
 volume = {117},
 year = {2007}
 }
 @article{Blanden.2008,
 author = {Bladen, Jo and Gregg, Paul and Macmillan, Lindsey},
 journal = {Unpublished Manuscript},
-title = {{{\{}I{\}}ntergenerational {\{}P{\}}ersistence in {\{}I{\}}ncome and {\{}S{\}}ocial {\{}C{\}}lass: {\{}T{\}}he {\{}I{\}}mpact of {\{}W{\}}ithin-{\{}G{\}}roup {\{}I{\}}nequality}},
+title = {{Intergenerational Persistence in Income and Social Class: The Impact of Within-Group Inequality}},
 year = {2008}
 }
 @article{Blair.2006,
@@ -1682,7 +1682,7 @@ author = {Blair, Clancy and Razza, Rachel P},
 journal = {Child Development},
 number = {2},
 pages = {647--663},
-title = {{{\{}R{\}}elating {\{}E{\}}ffortful {\{}C{\}}ontrol, {\{}E{\}}xecutive {\{}F{\}}unction, and {\{}F{\}}alse {\{}B{\}}elief {\{}U{\}}nderstanding to {\{}E{\}}merging {\{}M{\}}ath and {\{}L{\}}iteracy {\{}A{\}}bility in {\{}K{\}}indergarten}},
+title = {{Relating Effortful Control, Executive Function, and False Belief Understanding to Emerging Math and Literacy Ability in Kindergarten}},
 volume = {78},
 year = {2007}
 }
@@ -1690,7 +1690,7 @@ year = {2007}
 address = {Milwaukee, WI},
 editor = {Blankenhorn, David and Bayme, Steven and Elshtain, Jean B},
 publisher = {Family Service America},
-title = {{{\{}R{\}}ebuilding the {\{}N{\}}est: {\{}A{\}} {\{}N{\}}ew {\{}C{\}}ommitment to {\{}A{\}}merican {\{}F{\}}amily}},
+title = {{Rebuilding the Nest: A New Commitment to American Family}},
 year = {1990}
 }
 @article{Blau.1999,
@@ -1698,7 +1698,7 @@ author = {Blau, David M},
 journal = {The Journal of Human Resources},
 number = {4},
 pages = {786--822},
-title = {{{\{}T{\}}he {\{}E{\}}ffect of {\{}C{\}}hild {\{}C{\}}are {\{}C{\}}haracteristics on {\{}C{\}}hild {\{}D{\}}evelopment}},
+title = {{The Effect of Child Care Characteristics on Child Development}},
 volume = {34},
 year = {1999}
 }
@@ -1707,7 +1707,7 @@ author = {Blau, David M and van der Klaauw, Wilbert},
 journal = {Review of Economics of the Household},
 number = {3},
 pages = {193--221},
-title = {{{\{}A{\}} {\{}D{\}}emographic {\{}A{\}}nalysis of the {\{}F{\}}amily {\{}S{\}}tructure {\{}E{\}}xperieces of {\{}C{\}}hildren in the {\{}U{\}}nited {\{}S{\}}tates}},
+title = {{A Demographic Analysis of the Family Structure Experieces of Children in the United States}},
 volume = {6},
 year = {2008}
 }
@@ -1716,7 +1716,7 @@ author = {Blau, Francine D and Kahn, Lawrence M},
 journal = {Journal of Political Economy},
 number = {4},
 pages = {791--837},
-title = {{{\{}I{\}}nternational {\{}D{\}}ifferences in {\{}M{\}}ale {\{}W{\}}age {\{}I{\}}nequality:{\$}{\~{}}{\$}{\{}I{\}}nstitutions versus {\{}M{\}}arket {\{}F{\}}orces}},
+title = {{International Differences in Male Wage Inequality: Institutions versus Market Forces}},
 volume = {104},
 year = {1996}
 }
@@ -1737,14 +1737,14 @@ year = {2016}
 @article{Blomeyer.2008,
 author = {Blomeyer, Dorothea and Coneus, Katja and Laucht, Manfred and Pfeiffer, Friedhelm},
 journal = {Working Paper},
-title = {{{\{}I{\}}nitial {\{}R{\}}isk {\{}M{\}}atrix, {\{}H{\}}ome {\{}R{\}}esources, {\{}A{\}}bility {\{}D{\}}evelopment and {\{}C{\}}hildren's {\{}A{\}}chievement:{\$}{\~{}}{\$}{\{}E{\}}vidence from {\{}M{\}}{\{}A{\}}{\{}R{\}}{\{}S{\}}}},
+title = {{Initial Risk Matrix, Home Resources, Ability Development and Children's Achievement: Evidence from MARS}},
 volume = {ZEW Mannhe},
 year = {2008}
 }
 @article{Blomeyer.2009,
 author = {Blomeyer, Dorothea and Coneus, Katja and Laucht, Manfred and Pfeiffer, Friedhelm},
 journal = {Working Paper},
-title = {{{\{}P{\}}erinatal {\{}C{\}}onditions, {\{}H{\}}ome {\{}R{\}}esources and {\{}C{\}}ompetencies in the {\{}E{\}}arly {\{}L{\}}ife {\{}C{\}}ourse}},
+title = {{Perinatal Conditions, Home Resources and Competencies in the Early Life Course}},
 volume = {ZEW Mannhe},
 year = {2009}
 }
@@ -1752,7 +1752,7 @@ year = {2009}
 author = {Bloom, Howard S},
 journal = {Evaluation Review},
 pages = {225--246},
-title = {{{\{}A{\}}ccounting for {\{}N{\}}o-{\{}S{\}}hows in {\{}E{\}}xperimental {\{}E{\}}valuation {\{}D{\}}esigns}},
+title = {{Accounting for No-Shows in Experimental Evaluation Designs}},
 volume = {8},
 year = {1984}
 }
@@ -1767,7 +1767,7 @@ year = {2005}
 address = {Boulder, Colorado},
 author = {Blossfeld, Hans-Peter and {Shavit Yossi}},
 publisher = {Westview Press},
-title = {{{\{}P{\}}erisitent {\{}I{\}}nequality: {\{}C{\}}hanging {\{}E{\}}ducational {\{}A{\}}ttainment in {\{}T{\}}hirteen {\{}C{\}}ountries}},
+title = {{Perisitent Inequality: Changing Educational Attainment in Thirteen Countries}},
 year = {1993}
 }
 @incollection{Blundell.1990,
@@ -1792,7 +1792,7 @@ author = {Blundell, Richard and Dearden, Lorraine and Sinesi, Barbara},
 journal = {Journal of the Royal Statistical Society A},
 number = {3},
 pages = {473--512},
-title = {{{\{}E{\}}valuating the {\{}E{\}}ffect of {\{}E{\}}ducation on {\{}E{\}}arnings: {\{}M{\}}odels, {\{}M{\}}ethods and {\{}R{\}}esults from the {\{}N{\}}ational {\{}C{\}}hild {\{}D{\}}evelopment {\{}S{\}}urvey}},
+title = {{Evaluating the Effect of Education on Earnings: Models, Methods and Results from the National Child Development Survey}},
 volume = {168},
 year = {2005}
 }
@@ -1808,10 +1808,10 @@ year = {1999}
 @incollection{Blundell.2003,
 address = {Cambridge, UK},
 author = {Blundell, Richard and Powell, James},
-booktitle = {{\{}A{\}}dvances in {\{}E{\}}conometrics:{\$}{\~{}}{\$}{\{}T{\}}heory and {\{}A{\}}pplications, {\{}E{\}}igth {\{}W{\}}orld {\{}C{\}}ongress},
+booktitle = {Advances in Econometrics: Theory and Applications, Eigth World Congress},
 editor = {Hansen, Lars P and Dewatripont, Mathias and Turnovsky, Stephen J},
 publisher = {Cambridge University Press},
-title = {{{\{}E{\}}ndogeneity in {\{}N{\}}onparametric and {\{}S{\}}emiparametric {\{}R{\}}egression {\{}M{\}}odels}},
+title = {{Endogeneity in Nonparametric and Semiparametric Regression Models}},
 volume = {2},
 year = {2003}
 }
@@ -1820,7 +1820,7 @@ author = {Blundell, Richard and Powell, James},
 journal = {Review of Economic Studies},
 number = {71},
 pages = {655--679},
-title = {{{\{}E{\}}ndogeneity in {\{}S{\}}emiparametric {\{}B{\}}inary {\{}R{\}}esponse {\{}M{\}}odels}},
+title = {{Endogeneity in Semiparametric Binary Response Models}},
 volume = {71},
 year = {2004}
 }
@@ -1836,7 +1836,7 @@ year = {2013}
 address = {New York, NY},
 author = {Bollen, Kenneth A},
 publisher = {Wiley},
-title = {{{\{}S{\}}tructural {\{}E{\}}quations with {\{}L{\}}atent {\{}V{\}}ariables}},
+title = {{Structural Equations with Latent Variables}},
 year = {1989}
 }
 @article{Bollerslev.2015,
@@ -1850,11 +1850,11 @@ year = {2015}
 @incollection{Bond.2001,
 address = {Amsterdam, NL},
 author = {Bond, Stephen and van Reen, JOhn},
-booktitle = {{\{}H{\}}andbook of {\{}E{\}}conometrics},
+booktitle = {Handbook of Econometrics},
 editor = {Heckman, James J and Leamer, Edward E},
 pages = {4417--4498},
 publisher = {Elsevier Science},
-title = {{{\{}M{\}}icroeconomic{\$}{\~{}}{\$}{\{}M{\}}odels of {\{}I{\}}nvestment and {\{}E{\}}mployment}},
+title = {{Microeconomic Models of Investment and Employment}},
 year = {2001}
 }
 @article{Borghans.2008b,
@@ -1862,7 +1862,7 @@ author = {Borghans, Lex and Duckworth, Angela L and Heckman, James J and ter Wee
 journal = {Journal of Human Resources},
 number = {4},
 pages = {815--858},
-title = {{{\{}T{\}}he {\{}E{\}}conomics and {\{}P{\}}sychology of {\{}C{\}}ognitive and {\{}N{\}}on-{\{}C{\}}ognitive {\{}T{\}}raits}},
+title = {{The Economics and Psychology of Cognitive and Non-Cognitive Traits}},
 volume = {43},
 year = {2008}
 }
@@ -1870,7 +1870,7 @@ year = {2008}
 author = {Borghans, Lex and Duckworth, Angela L and Heckman, James J and ter Weel, Bas},
 journal = {IZA Discussion Paper},
 number = {No. 3333},
-title = {{{\{}T{\}}he {\{}E{\}}conomics and {\{}P{\}}sychology of {\{}P{\}}ersonality {\{}T{\}}raits}},
+title = {{The Economics and Psychology of Personality Traits}},
 year = {2008}
 }
 @article{Borghans.2008c,
@@ -1878,14 +1878,14 @@ author = {Borghans, Lex and ter Weel, Bas and Weinberg, Bruce A},
 journal = {The Journal of Human Resources},
 number = {4},
 pages = {815--858},
-title = {{{\{}I{\}}nterpersonal {\{}S{\}}tyles and {\{}L{\}}abor {\{}M{\}}arket {\{}O{\}}utcomes}},
+title = {{Interpersonal Styles and Labor Market Outcomes}},
 volume = {43},
 year = {2008}
 }
 @article{Borjas.2006,
 author = {Borjas, George},
 journal = {NBER Working Paper},
-title = {{{\{}M{\}}aking it in {\{}A{\}}merica: {\{}S{\}}ocial {\{}M{\}}obility in the {\{}I{\}}mmigrant {\{}P{\}}opulation}},
+title = {{Making it in America: Social Mobility in the Immigrant Population}},
 volume = {12088},
 year = {2006}
 }
@@ -1934,7 +1934,7 @@ author = {Bowles, Samuel},
 journal = {The Journal of Political Economy},
 number = {3},
 pages = {S219----S251},
-title = {{{\{}S{\}}chooling and {\{}I{\}}nequality from {\{}G{\}}eneration to {\{}G{\}}eneration}},
+title = {{Schooling and Inequality from Generation to Generation}},
 volume = {80},
 year = {1972}
 }
@@ -1942,7 +1942,7 @@ year = {1972}
 author = {Bowles, Samuel and Ginther, Donna K},
 journal = {Sociology of Education},
 pages = {1--18},
-title = {{{\{}S{\}}chooling in {\{}C{\}}apitalist {\{}A{\}}merica {\{}R{\}}evisisted}},
+title = {{Schooling in Capitalist America Revisisted}},
 volume = {75},
 year = {2002}
 }
@@ -1960,7 +1960,7 @@ author = {Bowles, Samuel and Gintis, Herbert and Osborne-Groves, Melissa},
 journal = {American Economic Review},
 number = {2},
 pages = {155--158},
-title = {{{\{}I{\}}ncentive-{\{}E{\}}nhancing {\{}P{\}}references: {\{}P{\}}ersonality, {\{}B{\}}ehavior and {\{}E{\}}arnings}},
+title = {{Incentive-Enhancing Preferences: Personality, Behavior and Earnings}},
 volume = {91},
 year = {2001}
 }
@@ -1968,7 +1968,7 @@ year = {2001}
 address = {Princeton, NJ},
 editor = {Bowles, Samuel and Gintis, Herbert and Osborne-Groves, Melissa},
 publisher = {Princeton University Press},
-title = {{{\{}U{\}}nequal {\{}C{\}}hances: {\{}F{\}}amily {\{}B{\}}ackground and {\{}E{\}}conomic {\{}S{\}}uccess}},
+title = {{Unequal Chances: Family Background and Economic Success}},
 year = {2005}
 }
 @article{Bowles.2001,
@@ -1976,14 +1976,14 @@ author = {Bowles, Samuel and Gintis, Herbert and Osborne-Groves, Melissa},
 journal = {Journal of Economic Literature},
 number = {4},
 pages = {1137--1176},
-title = {{{\{}T{\}}he {\{}D{\}}eterminants of {\{}E{\}}arnings:{\$}{\~{}}{\$}{\{}A{\}} {\{}B{\}}ehavioral {\{}A{\}}pproach}},
+title = {{The Determinants of Earnings: A Behavioral Approach}},
 volume = {39},
 year = {2001}
 }
 @article{Bowles.2008,
 author = {Bowles, Samuel and Loury, Glenn C and Sethi, Rajiv},
 journal = {Unpublished Manuscript},
-title = {{{\{}G{\}}roup {\{}I{\}}nequality}},
+title = {{Group Inequality}},
 year = {2008}
 }
 @article{Bradbury.2008,
@@ -1991,23 +1991,23 @@ author = {Bradbury, Bruce},
 journal = {Review of Income and Wealth},
 number = {3},
 pages = {305--323},
-title = {{{\{}T{\}}ime and {\{}C{\}}ost of {\{}C{\}}hildren}},
+title = {{Time and Cost of Children}},
 volume = {54},
 year = {2008}
 }
 @article{Bratsberg.2007,
-author = {Bratsberg, Bernt and R{\o}ed, Knut and Raaum, Oddbj{\o}rn and Naylor, Robin and J{\"{a}}ntti, Markus and Erikson, Tor and {\"{O}}sterbacka, Eva},
+author = {Bratsberg, Bernt and R{\o}ed, Knut and Raaum, Oddbj\"{o}rn and Naylor, Robin and J\"{a}ntti, Markus and Erikson, Tor and \"{O}sterbacka, Eva},
 journal = {The Economic Journal},
 number = {519},
 pages = {C72----C92},
-title = {{{\{}N{\}}onlinearities in {\{}I{\}}ntergenerational {\{}E{\}}arnings {\{}M{\}}obility: {\{}C{\}}onsequences for {\{}C{\}}ross-{\{}C{\}}ountry {\{}C{\}}omparisons}},
+title = {{Nonlinearities in Intergenerational Earnings Mobility: Consequences for Cross-Country Comparisons}},
 volume = {117},
 year = {2007}
 }
 @article{Bratti.2008,
 author = {Bratti, Massimiliano and Checchi, Daniele and Blasio, Guido},
 journal = {IZA Discussion Paper},
-title = {{{\{}D{\}}oes the {\{}E{\}}xpansion of {\{}H{\}}igher {\{}E{\}}ducation {\{}I{\}}ncrease the {\{}E{\}}quality of {\{}E{\}}ducational {\{}O{\}}pportunities? {\{}E{\}}vidence from {\{}I{\}}taly}},
+title = {{Does the Expansion of Higher Education Increase the Equality of Educational Opportunities? Evidence from Italy}},
 volume = {No. 3361},
 year = {2008}
 }
@@ -2041,16 +2041,16 @@ year = {2011}
 @article{Brilli2012,
 author = {Brilli, Ylenia},
 journal = {Unpublished Manuscript},
-title = {{{\{}M{\}}other or {\{}M{\}}arket {\{}C{\}}are? {\{}A{\}} {\{}S{\}}tructural {\{}E{\}}stimation of {\{}C{\}}hild {\{}C{\}}are {\{}I{\}}mpacts on {\{}C{\}}hild {\{}D{\}}evelopment}},
+title = {{Mother or Market Care? A Structural Estimation of Child Care Impacts on Child Development}},
 year = {2012}
 }
 @incollection{Brinbaum.1968,
 address = {Reading, MA},
 author = {Brinbaum, A},
-booktitle = {{\{}S{\}}tatistical {\{}T{\}}heories of {\{}M{\}}ental {\{}T{\}}est {\{}S{\}}cores},
+booktitle = {Statistical Theories of Mental Test Scores},
 editor = {Lord, Frederic M and Novick, Melvin R},
 publisher = {Addison-Wesley},
-title = {{{\{}S{\}}ome {\{}L{\}}atent {\{}T{\}}rait {\{}M{\}}odels and {\{}T{\}}heir {\{}U{\}}se in {\{}I{\}}nferring {\{}E{\}}xaminee's {\{}A{\}}bility}},
+title = {{Some Latent Trait Models and Their Use in Inferring Examinee's Ability}},
 year = {1968}
 }
 @article{Brinch.2012,
@@ -2116,7 +2116,7 @@ author = {Brooks-Gunn, Jeanne and Duncan, Greg J},
 journal = {Future of Children},
 number = {2},
 pages = {549--588},
-title = {{{\{}T{\}}he {\{}E{\}}ffect of {\{}P{\}}overty on {\{}C{\}}hildren}},
+title = {{The Effect of Poverty on Children}},
 volume = {7},
 year = {1997}
 }
@@ -2125,7 +2125,7 @@ author = {Brooks-Gunn, Jeanne and Gross, Ruth and Kraemer, Helena and {Donna Spi
 journal = {Pediatrics},
 number = {6},
 pages = {1209--1215},
-title = {{{\{}E{\}}nhancing the {\{}C{\}}ognitive {\{}O{\}}utcomes of {\{}L{\}}ow {\{}B{\}}irth {\{}W{\}}eight, {\{}P{\}}remature {\{}I{\}}nfants: {\{}F{\}}or {\{}W{\}}hom {\{}I{\}}s the {\{}I{\}}ntervention {\{}M{\}}ost {\{}E{\}}ffective?}},
+title = {{Enhancing the Cognitive Outcomes of Low Birth Weight, Premature Infants: For Whom Is the Intervention Most Effective?}},
 volume = {89},
 year = {1992}
 }
@@ -2193,7 +2193,7 @@ year = {2010}
 address = {Washington, DC},
 author = {{Bureau of Labor Statistics}},
 publisher = {U.S. Department of Labor},
-title = {{{\{}N{\}}{\{}L{\}}{\{}S{\}} {\{}H{\}}anbook 2001: {\{}T{\}}he {\{}N{\}}ational {\{}L{\}}ongitudinal {\{}S{\}}urveys}},
+title = {{NLS Hanbook 2001: The National Longitudinal Surveys}},
 year = {2001}
 }
 @article{Burkard.2011,
@@ -2214,7 +2214,7 @@ author = {Burkhauser, Richard V and Poupore, John G},
 journal = {Review of Economics and Statistics},
 number = {1},
 pages = {10--17},
-title = {{{\{}A{\}} {\{}C{\}}ross-{\{}N{\}}ational {\{}C{\}}omparison of {\{}P{\}}ermanent {\{}I{\}}ncome {\{}I{\}}nequality}},
+title = {{A Cross-National Comparison of Permanent Income Inequality}},
 volume = {79},
 year = {1997}
 }
@@ -2230,14 +2230,14 @@ year = {2002}
 @article{Caliendo.2010,
 author = {Caliendo, Marco and Cobb-Clark, Deborah and Uhlendorff, Arne},
 journal = {IZA Discussion Paper},
-title = {{{\{}L{\}}ocus of {\{}C{\}}ontrol and {\{}J{\}}ob {\{}S{\}}earch {\{}S{\}}trategies}},
+title = {{Locus of Control and Job Search Strategies}},
 volume = {No. 1750},
 year = {2010}
 }
 @article{Caliendo.2011,
 author = {Caliendo, Marco and Falk, Armin and Kaiser, Lutz C and Schneider, Hilmar and Uhlendorff, Arne and van den Berg, Gerad and Zimmermann, Klaus F},
 journal = {IZA Discussion Paper},
-title = {{{\{}T{\}}he {\{}IZA{\}} {\{}E{\}}valuation {\{}D{\}}ataset: {\{}T{\}}owards {\{}E{\}}vidence-{\{}B{\}}ased {\{}L{\}}abor {\{}P{\}}olicy-{\{}M{\}}aking}},
+title = {{The {\{}IZA{\}} Evaluation Dataset: Towards Evidence-Based Labor Policy-Making}},
 volume = {No. 5400},
 year = {2011}
 }
@@ -2246,14 +2246,14 @@ author = {Caliendo, Marco and Hujer, Reinhard and Thomsen, Stephan L},
 journal = {Applied Economics},
 number = {9},
 pages = {1101--1122},
-title = {{{\{}I{\}}dentifying {\{}E{\}}ffect {\{}H{\}}eterogeneity to {\{}I{\}}mprove the {\{}E{\}}fficiency of {\{}J{\}}ob {\{}C{\}}reation {\{}S{\}}chemes in {\{}G{\}}ermany}},
+title = {{Identifying Effect Heterogeneity to Improve the Efficiency of Job Creation Schemes in Germany}},
 volume = {40},
 year = {2008}
 }
 @article{Caliendo.2009,
 author = {Caliendo, Marco and Tatsiramos, Konstantinos and Uhlendorff, Arne},
 journal = {Journal of Applied Econometrics},
-title = {{{\{}B{\}}enefit {\{}D{\}}uration, {\{}U{\}}nemployment {\{}D{\}}uration and {\{}J{\}}ob {\{}M{\}}atch {\{}Q{\}}uality: {\{}A{\}} {\{}R{\}}egression-{\{}D{\}}iscontinuity {\{}A{\}}pproach}},
+title = {{Benefit Duration, Unemployment Duration and Job Match Quality: A Regression-Discontinuity Approach}},
 volume = {forthcomin},
 year = {2012}
 }
@@ -2270,7 +2270,7 @@ author = {Cameron, Judy and Heckman, James J},
 journal = {Journal of Political Economy},
 number = {3},
 pages = {455--499},
-title = {{{\{}T{\}}he {\{}D{\}}ynamics of {\{}E{\}}ducational {\{}A{\}}ttainment for {\{}B{\}}lack, {\{}H{\}}ispanic, and {\{}W{\}}hite {\{}M{\}}ales}},
+title = {{The Dynamics of Educational Attainment for Black, Hispanic, and White Males}},
 volume = {112},
 year = {2001}
 }
@@ -2279,7 +2279,7 @@ author = {Cameron, Stephen V and Heckman, James J},
 journal = {Journal of Political Economy},
 number = {2},
 pages = {262--333},
-title = {{{\{}L{\}}ife {\{}C{\}}ycle {\{}S{\}}chooling and {\{}D{\}}ynamic {\{}S{\}}election {\{}B{\}}ias: {\{}M{\}}odels and {\{}E{\}}vidence for {\{}F{\}}ive {\{}C{\}}ohorts of {\{}A{\}}merican {\{}M{\}}ales}},
+title = {{Life Cycle Schooling and Dynamic Selection Bias: Models and Evidence for Five Cohorts of American Males}},
 volume = {106},
 year = {1998}
 }
@@ -2288,7 +2288,7 @@ author = {Cameron, Stephen V and Heckman, James J},
 journal = {Journal of Labor Economics},
 number = {1},
 pages = {1--47},
-title = {{{\{}T{\}}he {\{}N{\}}onequivalence of {\{}H{\}}igh {\{}S{\}}chool {\{}E{\}}quivalents}},
+title = {{The Nonequivalence of High School Equivalents}},
 volume = {11},
 year = {1993}
 }
@@ -2297,7 +2297,7 @@ author = {Cameron, Stephen V and Taber, Christoph},
 journal = {Journal of Political Economy},
 number = {1},
 pages = {132--182},
-title = {{{\{}E{\}}stimation of {\{}E{\}}ducational {\{}B{\}}orrowing {\{}C{\}}onstraints {\{}U{\}}sing {\{}R{\}}eturns to {\{}S{\}}chooling}},
+title = {{Estimation of Educational Borrowing Constraints Using Returns to Schooling}},
 volume = {112},
 year = {2004}
 }
@@ -2306,7 +2306,7 @@ author = {Cameron, Stephen V and Taber, Christoph},
 journal = {Journal of Political Economy},
 number = {1},
 pages = {132--182},
-title = {{{\{}E{\}}stimation of {\{}E{\}}ducational {\{}B{\}}orrowing {\{}C{\}}onstraints {\{}U{\}}sing {\{}R{\}}eturns to {\{}S{\}}chooling}},
+title = {{Estimation of Educational Borrowing Constraints Using Returns to Schooling}},
 volume = {112},
 year = {2004}
 }
@@ -2340,11 +2340,11 @@ year = {1999}
 @incollection{Card.1995,
 address = {Toronto, Canada},
 author = {Card, David},
-booktitle = {{\{}A{\}}spects of {\{}L{\}}abour {\{}M{\}}arket {\{}B{\}}ehaviour: {\{}E{\}}ssays in {\{}H{\}}onor of {\{}J{\}}ohn {\{}V{\}}anderkamp},
+booktitle = {Aspects of Labour Market Behaviour: Essays in Honor of John Vanderkamp},
 editor = {Christofides, Louis and Grant, Kenneth E and Swindinsky, Robert},
 pages = {201--222},
 publisher = {University of Toronto Press},
-title = {{{\{}U{\}}sing {\{}G{\}}eographic {\{}V{\}}ariation in {\{}C{\}}ollege {\{}P{\}}roximity to {\{}E{\}}stimate the {\{}R{\}}eturn to {\{}S{\}}chooling}},
+title = {{Using Geographic Variation in College Proximity to Estimate the Return to Schooling}},
 year = {1995}
 }
 @article{Card.2011,
@@ -2366,14 +2366,14 @@ year = {1992}
 @article{Carneiro.2007b,
 author = {Carneiro, Pedro and Crawford, Claire Goodman Alissa},
 journal = {CEE Working Paper},
-title = {{{\{}T{\}}he {\{}I{\}}mpact of {\{}E{\}}arly {\{}C{\}}ognitive and {\{}N{\}}on-{\{}C{\}}ognitive {\{}S{\}}kills on {\{}L{\}}ater {\{}O{\}}utcomes}},
+title = {{The Impact of Early Cognitive and Non-Cognitive Skills on Later Outcomes}},
 volume = {92},
 year = {2007}
 }
 @article{Carneiro.2006,
 author = {Carneiro, Pedro and Cunha, Flavio and Heckman, James J},
 journal = {Working Paper},
-title = {{{\{}T{\}}he {\{}T{\}}echnology of {\{}S{\}}kill {\{}F{\}}ormation}},
+title = {{The Technology of Skill Formation}},
 volume = {The Univer},
 year = {2006}
 }
@@ -2388,7 +2388,7 @@ author = {Carneiro, Pedro and Hansen, Karsten and Heckman, James J},
 journal = {International Economic Review},
 number = {2},
 pages = {361--422},
-title = {{{\{}E{\}}stimating {\{}D{\}}istributions of {\{}T{\}}reatment {\{}E{\}}ffects with an {\{}A{\}}pplication to the {\{}R{\}}eturns to {\{}S{\}}chooling and {\{}M{\}}easurement of the {\{}E{\}}ffects of {\{}U{\}}ncertainty on {\{}C{\}}ollege {\{}C{\}}hoice}},
+title = {{Estimating Distributions of Treatment Effects with an Application to the Returns to Schooling and Measurement of the Effects of Uncertainty on College Choice}},
 volume = {44},
 year = {2003}
 }
@@ -2396,7 +2396,7 @@ year = {2003}
 author = {Carneiro, Pedro and Hansen, Karsten and Heckman, James J},
 journal = {Swedish Economic Policy Review},
 pages = {273--301},
-title = {{{\{}R{\}}emoving the {\{}V{\}}eil of {\{}I{\}}gnorance in {\{}A{\}}ssessing the {\{}D{\}}istributional {\{}I{\}}mpacts of {\{}S{\}}ocial {\{}P{\}}olicies}},
+title = {{Removing the Veil of Ignorance in Assessing the Distributional Impacts of Social Policies}},
 volume = {8},
 year = {2001}
 }
@@ -2405,17 +2405,17 @@ author = {Carneiro, Pedro and Heckman, James J},
 journal = {The Economic Journal},
 number = {482},
 pages = {705--734},
-title = {{{\{}T{\}}he {\{}E{\}}vidence on {\{}C{\}}redit {\{}C{\}}onstraints in {\{}P{\}}ost-{\{}S{\}}econdary {\{}S{\}}chooling}},
+title = {{The Evidence on Credit Constraints in Post-Secondary Schooling}},
 volume = {112},
 year = {2002}
 }
 @incollection{Carneiro.2003b,
 address = {Cambridge, MA},
 author = {Carneiro, Pedro and Heckman, James J},
-booktitle = {{\{}I{\}}nequality in {\{}A{\}}merica: {\{}W{\}}hat {\{}R{\}}ole for {\{}H{\}}uman {\{}C{\}}apital {\{}P{\}}olicies?},
+booktitle = {Inequality in America: What Role for Human Capital Policies?},
 editor = {Heckman, James J and Krueger, Alan B},
-publisher = {MIT{\$}{\~{}}{\$}Press},
-title = {{{\{}H{\}}uman {\{}C{\}}apital {\{}P{\}}olicy}},
+publisher = {MIT Press},
+title = {{Human Capital Policy}},
 year = {2003}
 }
 @article{Carneiro.2010,
@@ -2423,7 +2423,7 @@ author = {Carneiro, Pedro and Heckman, James J and Vytlacil, Edward J},
 journal = {Econometrica},
 number = {1},
 pages = {377--394},
-title = {{{\{}E{\}}valuating {\{}M{\}}arginal {\{}P{\}}olicy {\{}C{\}}hanges and the {\{}A{\}}verage {\{}E{\}}ffect of {\{}T{\}}reatment for {\{}I{\}}ndividuals at the {\{}M{\}}argin}},
+title = {{Evaluating Marginal Policy Changes and the Average Effect of Treatment for Individuals at the Margin}},
 volume = {78},
 year = {2010}
 }
@@ -2440,13 +2440,13 @@ year = {2011}
 @article{Carneiro.2010b,
 author = {Carneiro, Pedro and Lee, Sokbae},
 journal = {Working Paper},
-title = {{{\{}E{\}}stimating {\{}P{\}}otential {\{}O{\}}utcome {\{}D{\}}istributions in {\{}L{\}}ocal {\{}I{\}}nstrumental {\{}V{\}}ariables {\{}M{\}}odels with an {\{}A{\}}pplication to {\{}C{\}}hanges in {\{}C{\}}ollege {\{}E{\}}nrollment and {\{}W{\}}age {\{}I{\}}nequality}},
+title = {{Estimating Potential Outcome Distributions in Local Instrumental Variables Models with an Application to Changes in College Enrollment and Wage Inequality}},
 year = {2010}
 }
 @article{Carneiro.2007,
 author = {Carneiro, Pedro and Meghir, Costas and Parey, Matthias},
 journal = {IZA Discussion Paper},
-title = {{{\{}M{\}}aternal {\{}E{\}}ducation, {\{}H{\}}ome {\{}E{\}}nvironments and the {\{}D{\}}evelopment of {\{}C{\}}hildren and {\{}A{\}}dolescents}},
+title = {{Maternal Education, Home Environments and the Development of Children and Adolescents}},
 volume = {No. 3072},
 year = {2007}
 }
@@ -2461,7 +2461,7 @@ year = {1996}
 }
 @article{Carrasco.2002,
 author = {Carrasco, Marine and Florens, Jean-Pierre},
-journal = {Journal of Business {\&} Economics and Statistics},
+journal = {Journal of Business \& Economics and Statistics},
 number = {4},
 pages = {482--492},
 title = {{Simulation-Based Method of Moments and Efficiency}},
@@ -2473,7 +2473,7 @@ author = {Case, Anne and Fertig, Angela and Paxson, Christina},
 journal = {Journal of Health Economics},
 number = {2},
 pages = {365--389},
-title = {{{\{}T{\}}he {\{}L{\}}asting {\{}I{\}}mpact of {\{}C{\}}hildhood {\{}H{\}}ealth and {\{}C{\}}ircumstance}},
+title = {{The Lasting Impact of Childhood Health and Circumstance}},
 volume = {24},
 year = {2005}
 }
@@ -2482,7 +2482,7 @@ author = {Case, Anne and Lubotsky, Darren and Paxson, Christina},
 journal = {American Economic Review},
 number = {5},
 pages = {1308--1334},
-title = {{{\{}E{\}}conomic {\{}S{\}}tatus and {\{}H{\}}ealth in {\{}C{\}}hildhood: {\{}T{\}}he {\{}O{\}}rigins of the {\{}G{\}}radient}},
+title = {{Economic Status and Health in Childhood: The Origins of the Gradient}},
 volume = {92},
 year = {2002}
 }
@@ -2491,7 +2491,7 @@ author = {Casella, George and George, Edward I},
 journal = {The American Statistican},
 number = {3},
 pages = {167--174},
-title = {{{\{}E{\}}xplaining the {\{}G{\}}ibbs {\{}S{\}}ampler}},
+title = {{Explaining the Gibbs Sampler}},
 volume = {46},
 year = {1992}
 }
@@ -2500,7 +2500,7 @@ author = {Caspi, Avshalom and Begg, Dot and Dickson, Nigel and Harrington, Hona-
 journal = {Journal of Personality and Social Psychology},
 number = {5},
 pages = {1052--1063},
-title = {{{\{}P{\}}ersonality {\{}D{\}}ifferences {\{}P{\}}redict {\{}H{\}}ealth-{\{}R{\}}isk {\{}B{\}}ehaviors in {\{}Y{\}}oung {\{}A{\}}dulthood: {\{}E{\}}vidence from a {\{}L{\}}ongitudinal {\{}S{\}}tudy}},
+title = {{Personality Differences Predict Health-Risk Behaviors in Young Adulthood: Evidence from a Longitudinal Study}},
 volume = {73},
 year = {1997}
 }
@@ -2515,7 +2515,7 @@ author = {Cawley, John},
 journal = {Journal of Human Resources},
 number = {2},
 pages = {451--474},
-title = {{{\{}T{\}}he {\{}I{\}}mpact of {\{}O{\}}besity on {\{}W{\}}ages}},
+title = {{The Impact of Obesity on Wages}},
 volume = {39},
 year = {2004}
 }
@@ -2532,7 +2532,7 @@ author = {Cawley, John and Heckman, James J and Vytlacil, Edward J},
 journal = {Labour Economics},
 number = {4},
 pages = {419--442},
-title = {{{\{}T{\}}hree {\{}O{\}}bservations on {\{}W{\}}ages and {\{}M{\}}easured {\{}C{\}}ognitive {\{}A{\}}bility}},
+title = {{Three Observations on Wages and Measured Cognitive Ability}},
 volume = {8},
 year = {2001}
 }
@@ -2541,7 +2541,7 @@ author = {Cawley, John and Rizzo, J A and Haas, K},
 journal = {Journal of Occupational and Environmental Medicine},
 number = {12},
 pages = {1317--1324},
-title = {{{\{}O{\}}ccupation-{\{}S{\}}pecific {\{}A{\}}bsenteeism {\{}C{\}}osts {\{}A{\}}ssociated with {\{}O{\}}besity and {\{}M{\}}orbid {\{}O{\}}besity}},
+title = {{Occupation-Specific Absenteeism Costs Associated with Obesity and Morbid Obesity}},
 volume = {49},
 year = {2007}
 }
@@ -2550,7 +2550,7 @@ author = {{Center for Disease Control} and Prevention},
 journal = {Journal of Schol Health},
 number = {1},
 pages = {9--26},
-title = {{{\{}G{\}}uidelines for {\{}S{\}}chool {\{}H{\}}ealth {\{}P{\}}rograms to {\{}P{\}}romote {\{}L{\}}ifelong {\{}H{\}}ealthy {\{}E{\}}ating}},
+title = {{Guidelines for School Health Programs to Promote Lifelong Healthy Eating}},
 volume = {67},
 year = {1997}
 }
@@ -2574,7 +2574,7 @@ year = {1986}
 address = {New Jersey, NJ},
 author = {Chamorro-Premuzic, Tomas and Furnham, Adrian},
 publisher = {Lawrence Erlbaum Associates},
-title = {{{\{}P{\}}ersonality and {\{}I{\}}ntellectual {\{}C{\}}ompetence}},
+title = {{Personality and Intellectual Competence}},
 year = {2005}
 }
 @article{Chan.1994,
@@ -2602,7 +2602,7 @@ year = {1999}
 address = {Cambridge, UK},
 author = {Checchi, Daniele},
 publisher = {Cambridge University Press},
-title = {{{\{}T{\}}he {\{}E{\}}conomics of {\{}E{\}}ducation: {\{}H{\}}uman {\{}C{\}}apital, {\{}F{\}}amily {\{}B{\}}ackground, and {\{}I{\}}nequality}},
+title = {{The Economics of Education: Human Capital, Family Background, and Inequality}},
 year = {2006}
 }
 @article{Chen.1981,
@@ -2610,7 +2610,7 @@ author = {Chen, Chan},
 journal = {Journal of the American Statistical Association},
 number = {375},
 pages = {704--708},
-title = {{{\{}T{\}}he {\{}E{\}}{\{}M{\}} {\{}A{\}}pproach to the {\{}M{\}}ultiple {\{}I{\}}ndicators and {\{}M{\}}ultiple {\{}C{\}}auses {\{}M{\}}odel {\{}V{\}}ia the {\{}E{\}}stimation of the {\{}L{\}}atent {\{}V{\}}ariable}},
+title = {{The EM Approach to the Multiple Indicators and Multiple Causes Model Via the Estimation of the Latent Variable}},
 volume = {76},
 year = {1981}
 }
@@ -2643,7 +2643,7 @@ author = {Chernozukov, Victor and Imbens, Guido W and Newey, Whitney},
 journal = {Journal of Econometrics},
 number = {1},
 pages = {4--14},
-title = {{{\{}I{\}}nstrumental {\{}V{\}}ariable {\{}E{\}}stimation of {\{}N{\}}onseparable {\{}M{\}}odels}},
+title = {{Instrumental Variable Estimation of Nonseparable Models}},
 volume = {139},
 year = {2007}
 }
@@ -2651,7 +2651,7 @@ year = {2007}
 address = {New York, NY},
 author = {Cherubini, U and Luciano, E and Vecchiato, W},
 publisher = {Wiley},
-title = {{{\{}C{\}}opula {\{}M{\}}ethods in {\{}F{\}}inance}},
+title = {{Copula Methods in Finance}},
 year = {2004}
 }
 @article{Chesher.2003,
@@ -2659,7 +2659,7 @@ author = {Chesher, Andrew},
 journal = {Econometrica},
 number = {5},
 pages = {1405--1441},
-title = {{{\{}I{\}}dentification in {\{}N{\}}onseparable {\{}M{\}}odels}},
+title = {{Identification in Nonseparable Models}},
 volume = {71},
 year = {2003}
 }
@@ -2674,18 +2674,18 @@ year = {2009}
 @incollection{Chib.2001,
 address = {Amsterdam, Netherlands},
 author = {Chib, Siddhartha},
-booktitle = {{\{}H{\}}andbook of {\{}E{\}}conometrics},
+booktitle = {Handbook of Econometrics},
 editor = {Heckman, James J and Leamer, Edward E},
 pages = {3569--3649},
 publisher = {Elsevier Science},
-title = {{{\{}M{\}}arkov {\{}C{\}}hain {\{}M{\}}onte {\{}C{\}}arlo {\{}M{\}}ethods: {\{}C{\}}omputation and {\{}I{\}}nference}},
+title = {{Markov Chain Monte Carlo Methods: Computation and Inference}},
 volume = {5},
 year = {2001}
 }
 @article{Chiburis.2010,
 author = {Chiburis, Richard C},
 journal = {Working Paper},
-title = {{{\{}S{\}}emiparametric {\{}B{\}}ounds on {\{}T{\}}reatment {\{}E{\}}ffects}},
+title = {{Semiparametric Bounds on Treatment Effects}},
 year = {2010}
 }
 @article{Cho.2010,
@@ -2717,21 +2717,21 @@ author = {Claessens, Amy and Duncan, Greg and Engel, Mimi},
 journal = {Economics of Education Review},
 number = {4},
 pages = {415--427},
-title = {{{\{}K{\}}indergarten {\{}S{\}}kills and {\{}F{\}}ifth-{\{}G{\}}rade {\{}A{\}}chievement: {\{}E{\}}vidence from the {\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}}},
+title = {{Kindergarten Skills and Fifth-Grade Achievement: Evidence from the ECLS-K}},
 volume = {28},
 year = {2009}
 }
 @article{Clark.2007,
 author = {Clark, Damon},
 journal = {IZA Discussion Paper},
-title = {{{\{}S{\}}elective {\{}S{\}}chools and {\{}A{\}}cademic {\{}A{\}}chievement}},
+title = {{Selective Schools and Academic Achievement}},
 volume = {No. 3182},
 year = {2007}
 }
 @article{Clark.2007a,
 author = {Clark, Damon},
 journal = {IZA Discussion Paper},
-title = {{{\{}S{\}}elective {\{}S{\}}chools and {\{}A{\}}cademic {\{}A{\}}chievement}},
+title = {{Selective Schools and Academic Achievement}},
 volume = {No. 3182},
 year = {2007}
 }
@@ -2779,7 +2779,7 @@ year = {2005}
 author = {Coleman, Margo and DeLaire, Thomas},
 journal = {Journal of Human Resources},
 pages = {701--721},
-title = {{{\{}A{\}}n {\{}E{\}}conomic {\{}M{\}}odel of {\{}L{\}}ocus of {\{}C{\}}ontrol and {\{}H{\}}uman {\{}C{\}}apital {\{}I{\}}nvestment {\{}D{\}}ecisions}},
+title = {{An Economic Model of Locus of Control and Human Capital Investment Decisions}},
 volume = {38},
 year = {2003}
 }
@@ -2788,7 +2788,7 @@ author = {Collard, Fabrice and Feve, Patrick and Perraudin, Corinne},
 journal = {Computational Economics},
 number = {3},
 pages = {201--221},
-title = {{{\{}S{\}}olving and {\{}E{\}}stimating {\{}D{\}}ynamic {\{}M{\}}odels under {\{}R{\}}ational {\{}E{\}}xpectations}},
+title = {{Solving and Estimating Dynamic Models under Rational Expectations}},
 volume = {15},
 year = {2000}
 }
@@ -2807,14 +2807,14 @@ year = {2011}
 address = {West Sussex, UK},
 author = {Congdon, Peter},
 publisher = {Wiley},
-title = {{{\{}B{\}}ayesian {\{}S{\}}tatistical {\{}M{\}}odelling}},
+title = {{Bayesian Statistical Modelling}},
 year = {2006}
 }
 @book{Congdon.2006,
 address = {West Sussex, UK},
 author = {Congdon, Peter},
 publisher = {Wiley},
-title = {{{\{}B{\}}ayesian {\{}S{\}}tatistical {\{}M{\}}odelling}},
+title = {{Bayesian Statistical Modelling}},
 year = {2006}
 }
 @article{Conlisk.1974,
@@ -2822,7 +2822,7 @@ author = {Conlisk, John},
 journal = {Journal of Law and Economics},
 number = {1},
 pages = {80--90},
-title = {{{\{}C{\}}an {\{}E{\}}qualization of {\{}O{\}}pportunity {\{}R{\}}educe {\{}S{\}}ocial {\{}M{\}}obility}},
+title = {{Can Equalization of Opportunity Reduce Social Mobility}},
 volume = {64},
 year = {1974}
 }
@@ -2836,12 +2836,12 @@ year = {2009}
 @article{Conti.2009,
 author = {Conti, Gabriella and Heckman, James J and Lopes, Hedibert and Pinto, Rodrigo R and Wang, Hongbo},
 journal = {Working Paper},
-title = {{{\{}T{\}}owards {\{}G{\}}reater {\{}U{\}}nderstanding of {\{}E{\}}arly-{\{}A{\}}dult {\{}R{\}}isk {\{}B{\}}ehaviors:{\$}{\~{}}{\$}{\{}C{\}}ognitive {\{}A{\}}bility, {\{}P{\}}ersonality, and {\{}S{\}}chooling {\{}E{\}}ffects}},
+title = {{Towards Greater Understanding of Early-Adult Risk Behaviors: Cognitive Ability, Personality, and Schooling Effects}},
 year = {2009}
 }
 @article{Conti.2010,
 author = {Conti, Gabriella and Heckman, James J and Urzua, Sergio},
-journal = {American Economic Review: Papers {\&} Proceedings},
+journal = {American Economic Review: Papers \& Proceedings},
 number = {2},
 pages = {234--238},
 title = {{The Education-Health Gradient}},
@@ -2851,7 +2851,7 @@ year = {2010}
 @article{Conti.2009b,
 author = {Conti, Gabriella and Heckman, James J and Urzua, Sergio},
 journal = {Unpublished Manuscript},
-title = {{{\{}E{\}}arly {\{}E{\}}ndowments, {\{}E{\}}ducation and {\{}H{\}}ealth}},
+title = {{Early Endowments, Education and Health}},
 volume = {The Univer},
 year = {2009}
 }
@@ -2868,7 +2868,7 @@ year = {1997}
 address = {Cambridge, UK},
 editor = {Corak, Miles},
 publisher = {Cambridge University Press},
-title = {{{\{}G{\}}enerational {\{}I{\}}ncome {\{}M{\}}obility in {\{}N{\}}orth {\{}A{\}}merica and {\{}E{\}}urope}},
+title = {{Generational Income Mobility in North America and Europe}},
 year = {2004}
 }
 @article{Corak.2008,
@@ -2876,7 +2876,7 @@ author = {Corak, Miles and Fertig, Michael and Tamm, Marcus},
 journal = {The Review of Income and Wealth},
 number = {4},
 pages = {547--571},
-title = {{{\{}A{\}} {\{}P{\}}ortrait of {\{}C{\}}hild {\{}P{\}}overty in {\{}G{\}}ermany}},
+title = {{A Portrait of Child Poverty in Germany}},
 volume = {54},
 year = {2008}
 }
@@ -2885,7 +2885,7 @@ author = {Corak, Miles and Heisz, Andrew},
 journal = {Journal of Human Resources},
 number = {3},
 pages = {504--533},
-title = {{{\{}T{\}}he {\{}I{\}}ntergenerational and {\{}E{\}}arnings {\{}M{\}}obility of {\{}C{\}}anadian {\{}M{\}}en: {\{}E{\}}vidence from {\{}L{\}}ongitudinal {\{}I{\}}ncome {\{}T{\}}ax {\{}D{\}}ata}},
+title = {{The Intergenerational and Earnings Mobility of Canadian Men: Evidence from Longitudinal Income Tax Data}},
 volume = {34},
 year = {1999}
 }
@@ -2893,7 +2893,7 @@ year = {1999}
 author = {Corcoran, Mary and Laren, Deborah and Gordon, Roger and Solon, Gary},
 journal = {The Journal of Human Resources},
 number = {3},
-title = {{{\{}A{\}} {\{}L{\}}ongitudinal {\{}A{\}}nalysis of {\{}S{\}}ibling {\{}C{\}}orrelation in {\{}E{\}}conomic {\{}S{\}}tatus}},
+title = {{A Longitudinal Analysis of Sibling Correlation in Economic Status}},
 volume = {26},
 year = {1991}
 }
@@ -2901,7 +2901,7 @@ year = {1991}
 author = {Corcoran, Mary and Laren, Deborah and Gordon, Roger and Solon, Gary},
 journal = {The Journal of Human Resources},
 number = {3},
-title = {{{\{}A{\}} {\{}L{\}}ongitudinal {\{}A{\}}nalysis of {\{}S{\}}ibling {\{}C{\}}orrelation in {\{}E{\}}conomic {\{}S{\}}tatus}},
+title = {{A Longitudinal Analysis of Sibling Correlation in Economic Status}},
 volume = {26},
 year = {1991}
 }
@@ -2928,7 +2928,7 @@ author = {Couch, Kenneth A and Dunn, Thomas A},
 journal = {The Journal of Human Resources},
 number = {1},
 pages = {210--232},
-title = {{{\{}I{\}}ntergenerational {\{}C{\}}orrelation in {\{}L{\}}abor {\{}M{\}}arket {\{}S{\}}tatus: {\{}A{\}} {\{}C{\}}omparison of the {\{}U{\}}nited {\{}S{\}}tates and {\{}G{\}}ermany}},
+title = {{Intergenerational Correlation in Labor Market Status: A Comparison of the United States and Germany}},
 volume = {32},
 year = {1997}
 }
@@ -2943,7 +2943,7 @@ year = {2012}
 address = {London, UK},
 editor = {{Cowles Comission}},
 publisher = {Wiley},
-title = {{{\{}C{\}}owles {\{}C{\}}omission for {\{}R{\}}esearch in {\{}E{\}}conomics}},
+title = {{Cowles Comission for Research in Economics}},
 year = {1953}
 }
 @article{Cowles.1996,
@@ -2951,7 +2951,7 @@ author = {Cowles, Mary K},
 journal = {Statistics and Computing},
 number = {2},
 pages = {1375--1573},
-title = {{{\{}A{\}}ccelerating {\{}M{\}}onte {\{}C{\}}arlo {\{}M{\}}arkov {\{}C{\}}hain {\{}C{\}}onvergence for {\{}C{\}}umulative-link {\{}G{\}}eneralized {\{}L{\}}inear {\{}M{\}}odels}},
+title = {{Accelerating Monte Carlo Markov Chain Convergence for Cumulative-link Generalized Linear Models}},
 volume = {6},
 year = {1996}
 }
@@ -2977,14 +2977,14 @@ year = {1996}
 address = {Amsterdam, NL},
 editor = {Culyer, Anthony J and Newhouse, Joseph P},
 publisher = {Elsevier Science},
-title = {{{\{}H{\}}andbook of {\{}H{\}}ealth {\{}E{\}}conomics}},
+title = {{Handbook of Health Economics}},
 year = {2000}
 }
 @book{Culyer.2000,
 address = {Amsterdam, NL},
 editor = {Culyer, Anthony J and Newhouse, Joseph P},
 publisher = {Elsevier Science},
-title = {{{\{}H{\}}andbook of {\{}H{\}}ealth {\{}E{\}}conomics}},
+title = {{Handbook of Health Economics}},
 year = {2000}
 }
 @article{Cunha.2007,
@@ -3003,7 +3003,7 @@ year = {2007}
 @article{Cunha.2007b,
 author = {Cunha, Flavio and Heckman, James J},
 journal = {IZA Discussion Paper},
-title = {{{\{}T{\}}he {\{}E{\}}volution of {\{}I{\}}nequality, {\{}H{\}}eterogeneity and {\{}U{\}}ncertainty in {\{}L{\}}abor {\{}E{\}}arnings in the {\{}U{\}}.{\{}S{\}}. {\{}E{\}}conomy}},
+title = {{The Evolution of Inequality, Heterogeneity and Uncertainty in Labor Earnings in the U.S. Economy}},
 volume = {No. 3115},
 year = {2007}
 }
@@ -3012,7 +3012,7 @@ author = {Cunha, Flavio and Heckman, James J},
 journal = {Journal of Human Resources},
 number = {4},
 pages = {738--782},
-title = {{{\{}F{\}}ormulating, {\{}I{\}}dentifying and {\{}E{\}}stimating the {\{}T{\}}echnology of {\{}C{\}}ognitive and {\{}N{\}}oncognitive {\{}S{\}}kill {\{}F{\}}ormation}},
+title = {{Formulating, Identifying and Estimating the Technology of Cognitive and Noncognitive Skill Formation}},
 volume = {43},
 year = {2008}
 }
@@ -3021,21 +3021,21 @@ author = {Cunha, Flavio and Heckman, James J},
 journal = {Journal of the European Economic Association},
 number = {2-3},
 pages = {320--364},
-title = {{{\{}T{\}}he {\{}E{\}}conomics and {\{}P{\}}sychology of {\{}I{\}}nequaliy and {\{}H{\}}uman {\{}D{\}}evelopment}},
+title = {{The Economics and Psychology of Inequaliy and Human Development}},
 volume = {7},
 year = {2009}
 }
 @article{Cunha.2006d,
 author = {Cunha, Flavio and Heckman, James J},
 journal = {Working Paper},
-title = {{{\{}I{\}}nvesting in {\{}O{\}}ur {\{}Y{\}}oung {\{}P{\}}eople}},
+title = {{Investing in Our Young People}},
 volume = {The Univer},
 year = {2006}
 }
 @article{Cunha.2007e,
 author = {Cunha, Flavio and Heckman, James J},
 journal = {IZA Discussion Paper},
-title = {{{\{}T{\}}he {\{}T{\}}echnology of {\{}S{\}}kill {\{}F{\}}ormation}},
+title = {{The Technology of Skill Formation}},
 volume = {No. 2550},
 year = {2007}
 }
@@ -3048,7 +3048,7 @@ number = {2},
 pages = {320--364},
 pmid = {20209045},
 title = {{The Economics and Psychology of Inequality and Human Development.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=2832600{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=2832600&tool=pmcentrez&rendertype=abstract},
 volume = {7},
 year = {2009}
 }
@@ -3057,7 +3057,7 @@ author = {Cunha, Flavio and Heckman, James J},
 journal = {Macroeconomic Dynamics},
 number = {S2},
 pages = {315--354},
-title = {{{\{}A{\}} {\{}N{\}}ew {\{}F{\}}ramework for the {\{}A{\}}nalysis of {\{}I{\}}nequality}},
+title = {{A New Framework for the Analysis of Inequality}},
 volume = {12},
 year = {2008}
 }
@@ -3065,18 +3065,18 @@ year = {2008}
 author = {Cunha, Flavio and Heckman, James J},
 journal = {Labour Economics},
 number = {870-893},
-title = {{{\{}I{\}}dentifying and {\{}E{\}}stimating the {\{}D{\}}istributions of ex-post and ex-ante {\{}R{\}}eturns to {\{}S{\}}chooling:{\$}{\~{}}{\$}{\{}A{\}}{\$}{\~{}}{\$}survey of recent {\{}D{\}}evelopments}},
+title = {{Identifying and Estimating the Distributions of ex-post and ex-ante Returns to Schooling: A survey of recent Developments}},
 volume = {14},
 year = {2007}
 }
 @incollection{Cunha.2006,
 address = {Amsterdam, NL},
 author = {Cunha, Flavio and Heckman, James J and Lochner, Lance and Masterov, Dimitriy V},
-booktitle = {{\{}H{\}}andbook of the {\{}E{\}}conomics of {\{}E{\}}ducation},
+booktitle = {Handbook of the Economics of Education},
 editor = {Hanushek, Eric A and Welch, John F},
 pages = {697--812},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}I{\}}nterpreting the {\{}E{\}}vidence on {\{}L{\}}ife {\{}C{\}}ycle {\{}S{\}}kill {\{}F{\}}ormation}},
+title = {{Interpreting the Evidence on Life Cycle Skill Formation}},
 volume = {2},
 year = {2006}
 }
@@ -3085,7 +3085,7 @@ author = {Cunha, Flavio and Heckman, James J and Navarro, Salvador},
 journal = {Oxford Economic Papers},
 number = {2},
 pages = {191--261},
-title = {{{\{}S{\}}eparating {\{}U{\}}ncertainty from {\{}H{\}}eterogeneity in {\{}L{\}}ife {\{}C{\}}ycle {\{}E{\}}arnings}},
+title = {{Separating Uncertainty from Heterogeneity in Life Cycle Earnings}},
 volume = {57},
 year = {2005}
 }
@@ -3099,14 +3099,14 @@ number = {3},
 pages = {883--931},
 pmid = {20563300},
 title = {{Estimating the Technology of Cognitive and Noncognitive Skill Formation.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=2885826{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=2885826&tool=pmcentrez&rendertype=abstract},
 volume = {78},
 year = {2010}
 }
 @article{Cunha.2009,
 author = {Cunha, Flavio and Heckman, James J and Schennach, Susanne},
 journal = {Working Paper},
-title = {{{\{}W{\}}ebappendix: {\{}E{\}}stimating the {\{}T{\}}echnology of {\{}C{\}}ognitive and {\{}N{\}}oncognitive {\{}S{\}}kill {\{}F{\}}ormation}},
+title = {{Webappendix: Estimating the Technology of Cognitive and Noncognitive Skill Formation}},
 volume = {The Univer},
 year = {2009}
 }
@@ -3124,14 +3124,14 @@ author = {Currie, Janet},
 journal = {Journal of Economic Perspectives},
 number = {2},
 pages = {213--238},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}E{\}}ducation {\{}P{\}}rograms}},
+title = {{Early Childhood Education Programs}},
 volume = {15},
 year = {2001}
 }
 @article{Currie.2008,
 author = {Currie, Janet},
 journal = {Journal of Economic Literature},
-title = {{{\{}H{\}}ealthy, {\{}W{\}}ealthy, and {\{}W{\}}ise? {\{}T{\}}he {\{}L{\}}ink {\{}B{\}}etween {\{}S{\}}{\{}E{\}}{\{}S{\}},{\$}{\~{}}{\$}{\{}C{\}}hildren's {\{}H{\}}ealth, and {\{}H{\}}uman {\{}C{\}}apital {\{}D{\}}evelopment}},
+title = {{Healthy, Wealthy, and Wise? The Link Between SES, Children's Health, and Human Capital Development}},
 volume = {forthcomin},
 year = {2008}
 }
@@ -3140,14 +3140,14 @@ author = {Currie, Janet and Duncan, Greg J},
 journal = {Journal of Human Resources},
 number = {4},
 pages = {755--774},
-title = {{{\{}S{\}}chool {\{}Q{\}}uality and the {\{}L{\}}onger-{\{}T{\}}erm{\$}{\~{}}{\$}{\{}E{\}}ffects of {\{}H{\}}ead {\{}S{\}}tart}},
+title = {{School Quality and the Longer-Term Effects of Head Start}},
 volume = {35},
 year = {2000}
 }
 @article{Currie.1999,
 author = {Currie, Janet and Dunn, Thomas A},
 journal = {NBER Working Paper},
-title = {{{\{}E{\}}arly {\{}T{\}}est {\{}S{\}}cores, {\{}S{\}}ocioeconomic {\{}S{\}}tatus and {\{}F{\}}uture {\{}O{\}}utcomes}},
+title = {{Early Test Scores, Socioeconomic Status and Future Outcomes}},
 volume = {6943},
 year = {1999}
 }
@@ -3156,7 +3156,7 @@ author = {Currie, Janet and Moretti, Enrico},
 journal = {The Quarterly Journal of Economics},
 number = {4},
 pages = {1495--1532},
-title = {{{\{}M{\}}other's {\{}E{\}}ducation and the {\{}I{\}}ntergenerational {\{}T{\}}ransmission of {\{}H{\}}uman {\{}C{\}}apital: {\{}E{\}}vidence from {\{}C{\}}ollege {\{}O{\}}penings}},
+title = {{Mother's Education and the Intergenerational Transmission of Human Capital: Evidence from College Openings}},
 volume = {118},
 year = {2003}
 }
@@ -3178,7 +3178,7 @@ author = {Cutler, David and Glaeser, Edward and Shapiro, Jesse},
 journal = {Journal of Economic Perspectives},
 number = {3},
 pages = {93--118},
-title = {{{\{}W{\}}hy have {\{}A{\}}mericans become more obese?}},
+title = {{Why have Americans become more obese?}},
 volume = {17},
 year = {2003}
 }
@@ -3186,38 +3186,38 @@ year = {2003}
 author = {Cutler, David and Lleras-Muney, Adriana},
 journal = {NBER Working Paper},
 number = {12352},
-title = {{{\{}U{\}}nderstanding {\{}D{\}}ifferences in {\{}H{\}}ealth {\{}B{\}}ehaviors by {\{}E{\}}ducation}},
+title = {{Understanding Differences in Health Behaviors by Education}},
 year = {2006}
 }
 @article{Dahl.2005,
 author = {Dahl, Gordon B and Lochner, Lance},
 journal = {NBER Working Paper},
-title = {{{\{}T{\}}he {\{}I{\}}mpact of {\{}F{\}}amily {\{}I{\}}ncome on {\{}C{\}}hild {\{}A{\}}chievement}},
+title = {{The Impact of Family Income on Child Achievement}},
 volume = {11279},
 year = {2005}
 }
 @article{Dahl.2008,
 author = {Dahl, Gordon B and Lochner, Lance},
 journal = {NBER Working Paper},
-title = {{{\{}T{\}}he {\{}I{\}}mpact of {\{}F{\}}amily {\{}I{\}}ncome on {\{}C{\}}hild {\{}A{\}}chievement:{\$}{\~{}}{\$}{\{}E{\}}vidence from{\$}{\~{}}{\$}the {\{}E{\}}arned {\{}I{\}}ncome {\{}T{\}}ax {\{}C{\}}redit}},
+title = {{The Impact of Family Income on Child Achievement: Evidence from the Earned Income Tax Credit}},
 volume = {14599},
 year = {2008}
 }
 @incollection{Dahl.2004,
 address = {New York, NY},
 author = {Dahl, Ronald E},
-booktitle = {{\{}A{\}}nnals of the {\{}N{\}}ew {\{}Y{\}}ork {\{}A{\}}cademy of {\{}S{\}}cience},
+booktitle = {Annals of the New York Academy of Science},
 editor = {Dahl, Ronald E and Spear, Linda P},
 pages = {1--22},
 publisher = {New York Academy of Science},
-title = {{{\{}A{\}}dolescent {\{}B{\}}rain {\{}D{\}}evelopment:{\$}{\~{}}{\$}{\{}A{\}} {\{}P{\}}eriod of {\{}V{\}}ulnerabilities and {\{}O{\}}pportunities}},
+title = {{Adolescent Brain Development: A Period of Vulnerabilities and Opportunities}},
 year = {2004}
 }
 @book{Dahl.2004b,
 address = {New York, NY},
 editor = {Dahl, Ronald E and Spear, Linda P},
 publisher = {New York Academy of Science},
-title = {{{\{}A{\}}nnals of the {\{}N{\}}ew {\{}Y{\}}ork {\{}A{\}}cademy of {\{}S{\}}cience}},
+title = {{Annals of the New York Academy of Science}},
 year = {2004}
 }
 @techreport{Dalcin.2012,
@@ -3231,7 +3231,7 @@ author = {Das, Mitali and Newey, Whitney and Vella, Francis},
 journal = {Review of Economic Studies},
 number = {1},
 pages = {33--58},
-title = {{{\{}N{\}}onparametric {\{}E{\}}stimation of {\{}S{\}}ample {\{}S{\}}election {\{}M{\}}odels}},
+title = {{Nonparametric Estimation of Sample Selection Models}},
 volume = {70},
 year = {2003}
 }
@@ -3284,14 +3284,14 @@ author = {Dearden, Lorraine and Machin, Steve and Reed, Howard},
 journal = {The Economic Journal},
 number = {440},
 pages = {47--66},
-title = {{{\{}I{\}}ntergenerational {\{}M{\}}obility in {\{}B{\}}ritain}},
+title = {{Intergenerational Mobility in Britain}},
 volume = {107},
 year = {1997}
 }
 @article{Deaton.2009,
 author = {Deaton, Angus},
 journal = {NBER Working Paper},
-title = {{{\{}I{\}}nstruments of {\{}D{\}}evelopment: {\{}R{\}}andomization in the {\{}T{\}}ropics, and the {\{}S{\}}earch for the {\{}E{\}}lusive {\{}K{\}}eys to {\{}E{\}}conomic {\{}D{\}}evelopment}},
+title = {{Instruments of Development: Randomization in the Tropics, and the Search for the Elusive Keys to Economic Development}},
 volume = {14690},
 year = {2009}
 }
@@ -3300,7 +3300,7 @@ author = {Deaton, Angus},
 journal = {Health Affairs},
 number = {2},
 pages = {13--30},
-title = {{{\{}P{\}}olicy {\{}I{\}}mplications of the {\{}G{\}}radient of {\{}H{\}}ealth and {\{}W{\}}ealth}},
+title = {{Policy Implications of the Gradient of Health and Wealth}},
 volume = {21},
 year = {2002}
 }
@@ -3308,7 +3308,7 @@ year = {2002}
 author = {Deb, Partha and Munkin, Murat K and Trivedi, Pravin K},
 journal = {Journal of Applied Econometrics},
 pages = {1081--1099},
-title = {{{\{}B{\}}ayesian {\{}A{\}}nalysis of the {\{}T{\}}wo-{\{}P{\}}art {\{}M{\}}odel with {\{}E{\}}ndogeneity: {\{}A{\}}pplication to {\{}H{\}}ealth {\{}C{\}}are {\{}E{\}}xpenditure}},
+title = {{Bayesian Analysis of the Two-Part Model with Endogeneity: Application to Health Care Expenditure}},
 volume = {21},
 year = {2006}
 }
@@ -3317,7 +3317,7 @@ author = {DeCicca, Philip},
 journal = {Economics of Education Review},
 number = {1},
 pages = {67--82},
-title = {{{\{}D{\}}oes {\{}F{\}}ull-{\{}D{\}}ay {\{}K{\}}indergarten {\{}M{\}}atter? {\{}E{\}}vidence from the {\{}F{\}}irst {\{}T{\}}wo {\{}Y{\}}ears of {\{}S{\}}chooling}},
+title = {{Does Full-Day Kindergarten Matter? Evidence from the First Two Years of Schooling}},
 volume = {26},
 year = {2007}
 }
@@ -3336,7 +3336,7 @@ year = {2008}
 }
 @article{Dehejia.2003,
 author = {Dehejia, R H},
-journal = {Journal of Business {\&} Economic Statistics},
+journal = {Journal of Business \& Economic Statistics},
 number = {1},
 pages = {1--11},
 title = {{Was There a Riverside Miracle? A Hierarchical Framework for Evaluating Programs With Grouped Data}},
@@ -3348,7 +3348,7 @@ author = {Dehejia, Rajeev H},
 journal = {Journal of Econometrics},
 number = {1-2},
 pages = {141--173},
-title = {{{\{}P{\}}rogram {\{}E{\}}valuation as a {\{}D{\}}ecision {\{}P{\}}roblem}},
+title = {{Program Evaluation as a Decision Problem}},
 volume = {125},
 year = {2005}
 }
@@ -3374,7 +3374,7 @@ year = {2012}
 @article{DelBono.2008,
 author = {{Del Bono}, Emilia and Ermisch, John and Francesconi, Marco},
 journal = {IZA Discussion Paper},
-title = {{{\{}I{\}}ntra-{\{}F{\}}amily {\{}R{\}}esource {\{}A{\}}llocation: {\{}A{\}} {\{}D{\}}ynamic {\{}M{\}}odel of {\{}B{\}}irth {\{}W{\}}eight}},
+title = {{Intra-Family Resource Allocation: A Dynamic Model of Birth Weight}},
 volume = {No. 3704},
 year = {2008}
 }
@@ -3389,7 +3389,7 @@ author = {Demaray, Michelle and Ruffalo, Stacey},
 journal = {School Psychology Review},
 number = {4},
 pages = {648--672},
-title = {{{\{}S{\}}ocial {\{}S{\}}kills {\{}A{\}}ssessment:{\$}{\~{}}{\$}{\{}A{\}}{\$}{\~{}}{\$}{\{}C{\}}omparative {\{}E{\}}valuation of {\{}S{\}}ix {\{}P{\}}ublished {\{}R{\}}ating{\$}{\~{}}{\$}{\{}S{\}}cales}},
+title = {{Social Skills Assessment: A Comparative Evaluation of Six Published Rating Scales}},
 volume = {24},
 year = {1995}
 }
@@ -3413,7 +3413,7 @@ author = {Dempster, A P and Laird, N M and Rubin, D B},
 journal = {Journal of the Royal Statistical Society B},
 number = {1},
 pages = {1--38},
-title = {{{\{}M{\}}aximum {\{}L{\}}ikelihood from {\{}I{\}}ncomplete {\{}D{\}}ata via {\{}E{\}}{\{}M{\}}{\$}{\~{}}{\$}{\{}A{\}}lgorithm}},
+title = {{Maximum Likelihood from Incomplete Data via EM Algorithm}},
 volume = {39},
 year = {1977}
 }
@@ -3434,13 +3434,13 @@ year = {1982}
 address = {New York, NY},
 editor = {Devlin, Bernie and Fienberg, Stephen E and Resnick, Daniel P and Roeder, Kathryn},
 publisher = {Springer},
-title = {{{\{}I{\}}ntelligence, {\{}G{\}}enes, and {\{}S{\}}uccess: {\{}S{\}}cientists {\{}R{\}}esponse to the {\{}B{\}}ell {\{}C{\}}urve}},
+title = {{Intelligence, Genes, and Success: Scientists Response to the Bell Curve}},
 year = {2007}
 }
 @article{Devroye.2001,
 author = {Devroye, Dan and Freeman, Richard},
 journal = {NBER Working Paper},
-title = {{{\{}D{\}}oes {\{}I{\}}nequality in {\{}S{\}}kills {\{}E{\}}xplain {\{}I{\}}nequality of {\{}E{\}}arnings {\{}A{\}}cross {\{}A{\}}dvanced {\{}C{\}}ountries?}},
+title = {{Does Inequality in Skills Explain Inequality of Earnings Across Advanced Countries?}},
 volume = {8140},
 year = {2001}
 }
@@ -3475,7 +3475,7 @@ author = {Diebolt, Jean and Robert, Christian P},
 journal = {Journal of the Royal Statistical Society B},
 number = {2},
 pages = {363--375},
-title = {{{\{}E{\}}stimation of {\{}F{\}}inite {\{}M{\}}ixture {\{}D{\}}istributions {\{}T{\}}hrough {\{}B{\}}ayesian {\{}S{\}}ampling}},
+title = {{Estimation of Finite Mixture Distributions Through Bayesian Sampling}},
 volume = {56},
 year = {1994}
 }
@@ -3493,7 +3493,7 @@ author = {DiNardo, John and Fortin, Nicole M and Lemieux, Thomas},
 journal = {Econometrica},
 number = {5},
 pages = {1001--1044},
-title = {{{\{}L{\}}abor {\{}M{\}}arket {\{}I{\}}nstitutions and the {\{}D{\}}istribution of {\{}W{\}}ages, 1973 - 1992:{\$}{\~{}}{\$}{\{}A{\}} {\{}S{\}}emiparametric {\{}A{\}}pproach}},
+title = {{Labor Market Institutions and the Distribution of Wages, 1973 - 1992: A Semiparametric Approach}},
 volume = {64},
 year = {1996}
 }
@@ -3520,7 +3520,7 @@ year = {2009}
 author = {Dobbie, Will and Fryer, Roland G},
 journal = {NBER Working Paper},
 number = {15473},
-title = {{{\{}A{\}}re {\{}H{\}}igh {\{}Q{\}}uality {\{}S{\}}chools {\{}E{\}}nough to {\{}C{\}}lose the {\{}A{\}}chievement {\{}G{\}}ap?{\$}{\~{}}{\$}{\{}E{\}}vidence from a {\{}S{\}}ocial {\{}E{\}}xperiment in {\{}H{\}}arlem}},
+title = {{Are High Quality Schools Enough to Close the Achievement Gap? Evidence from a Social Experiment in Harlem}},
 year = {2009}
 }
 @article{Dohmen2010,
@@ -3551,7 +3551,7 @@ year = {2009}
 @article{Dohmen.2007,
 author = {Dohmen, Thomas and Falk, Armin and Huffman, David and Sunde, Uwe},
 journal = {IZA Discussion Paper},
-title = {{{\{}A{\}}re {\{}R{\}}isk {\{}A{\}}version and {\{}I{\}}mpatience {\{}R{\}}elated to {\{}C{\}}ognitive {\{}A{\}}bility?}},
+title = {{Are Risk Aversion and Impatience Related to Cognitive Ability?}},
 volume = {No. 2735},
 year = {2007}
 }
@@ -3613,7 +3613,7 @@ author = {Drton, Mathias},
 journal = {The Annals of Statistics},
 number = {2},
 pages = {979--1012},
-title = {{{\{}L{\}}ikelihood {\{}R{\}}atio {\{}T{\}}ests and {\{}S{\}}ingularities}},
+title = {{Likelihood Ratio Tests and Singularities}},
 volume = {37},
 year = {2009}
 }
@@ -3622,7 +3622,7 @@ author = {Duckworth, Angela L and Seligman, Martin E P},
 journal = {American Psychological Society},
 number = {2},
 pages = {939--944},
-title = {{{\{}S{\}}elf-{\{}D{\}}iscipline {\{}O{\}}utdoes {\{}I{\}}{\{}Q{\}} in {\{}P{\}}rediciting {\{}A{\}}cademic {\{}P{\}}erformance of {\{}A{\}}dolescents}},
+title = {{Self-Discipline Outdoes IQ in Prediciting Academic Performance of Adolescents}},
 volume = {16},
 year = {2005}
 }
@@ -3630,7 +3630,7 @@ year = {2005}
 author = {Duckworth, Angela and Almlund, Mathilde and Heckman, James J and Kautz, Tim},
 journal = {Handbook of the Economics of Education},
 pages = {forthcoming},
-title = {{{\{}T{\}}he {\{}R{\}}elevance of {\{}P{\}}ersonality {\{}P{\}}sychology for {\{}E{\}}conomics}},
+title = {{The Relevance of Personality Psychology for Economics}},
 year = {2011}
 }
 @article{Duffie.1993,
@@ -3646,17 +3646,17 @@ year = {1993}
 address = {New York, NY},
 editor = {Duncan, Greg J},
 publisher = {Russell Sage Foundation},
-title = {{{\{}C{\}}onsequences of {\{}G{\}}rowing up {\{}P{\}}oor}},
+title = {{Consequences of Growing up Poor}},
 year = {1997}
 }
 @incollection{Duncan.1997,
 address = {New York, NY},
 author = {Duncan, Greg J and Brooks-Gunn, Jeanne},
-booktitle = {{\{}C{\}}onsequences of {\{}G{\}}rowing up {\{}P{\}}oor},
+booktitle = {Consequences of Growing up Poor},
 editor = {Duncan, Greg J},
 pages = {596--610},
 publisher = {Russell Sage Foundation},
-title = {{{\{}I{\}}ncome {\{}E{\}}ffects {\{}A{\}}cross the {\{}L{\}}ife {\{}S{\}}pan: {\{}I{\}}ntegration and {\{}I{\}}nterpretation}},
+title = {{Income Effects Across the Life Span: Integration and Interpretation}},
 year = {1997}
 }
 @article{Duncan.2008,
@@ -3664,7 +3664,7 @@ author = {Duncan, Greg J and Dowsett, Chantelle J and Claessens, Amy and Magnuso
 journal = {Developmental Psychology},
 number = {6},
 pages = {1428--1446},
-title = {{{\{}S{\}}chool {\{}R{\}}eadiness and {\{}L{\}}ater {\{}A{\}}chievement}},
+title = {{School Readiness and Later Achievement}},
 volume = {43},
 year = {2007}
 }
@@ -3673,7 +3673,7 @@ author = {Duncan, Greg J and Gibson-Davis, Christina},
 journal = {Evaluation Review},
 number = {5},
 pages = {611--630},
-title = {{{\{}C{\}}onnecting {\{}C{\}}hild {\{}C{\}}are {\{}O{\}}utcomes:{\$}{\~{}}{\$}{\{}D{\}}rawing {\{}P{\}}olicy {\{}L{\}}essons from {\{}N{\}}onexperimental {\{}D{\}}ata}},
+title = {{Connecting Child Care Outcomes: Drawing Policy Lessons from Nonexperimental Data}},
 volume = {30},
 year = {2006}
 }
@@ -3682,7 +3682,7 @@ author = {Duncan, Greg J and Hill, Daniel H},
 journal = {Journal of Labor Economics},
 number = {4},
 pages = {508--532},
-title = {{{\{}A{\}}n {\{}I{\}}nvestigation of the {\{}E{\}}xtent and {\{}C{\}}onsequences of {\{}M{\}}easurement {\{}E{\}}rror in {\{}L{\}}abor-{\{}E{\}}conomic {\{}S{\}}urvey {\{}D{\}}ata}},
+title = {{An Investigation of the Extent and Consequences of Measurement Error in Labor-Economic Survey Data}},
 volume = {3},
 year = {1985}
 }
@@ -3690,7 +3690,7 @@ year = {1985}
 address = {Cambridge, MA},
 author = {Durbin, James and Koopman, Siem J},
 publisher = {Cambridge University Press},
-title = {{{\{}T{\}}ime {\{}S{\}}eries {\{}A{\}}nalysis by {\{}S{\}}tate {\{}S{\}}pace {\{}M{\}}ethods}},
+title = {{Time Series Analysis by State Space Methods}},
 year = {2002}
 }
 @article{Durlauf.1996,
@@ -3698,14 +3698,14 @@ author = {Durlauf, Steven N},
 journal = {Journal of Economic Growth},
 number = {1},
 pages = {75--93},
-title = {{{\{}A{\}} {\{}T{\}}heory of {\{}P{\}}ersistent {\{}I{\}}ncome {\{}I{\}}nequality}},
+title = {{A Theory of Persistent Income Inequality}},
 year = {1996}
 }
 @book{Durlauf.2008,
 address = {New York, NY},
 editor = {Durlauf, Steven N and Blume, Lawrence E},
 publisher = {Palgrave},
-title = {{{\{}T{\}}he {\{}N{\}}ew {\{}P{\}}algrave {\{}D{\}}ictionary of {\{}E{\}}conomics}},
+title = {{The New Palgrave Dictionary of Economics}},
 year = {2008}
 }
 @incollection{Durlauf.2001,
@@ -3724,7 +3724,7 @@ year = {2001}
 abstract = {This paper studies parental investment in education and intergenerational earnings mobility for father-son pairs with native and foreign born fathers. We illustrate within a simple model that for immigrants, investment in their children is related to their return migration probability. In our empirical analysis, we include a measure for return probabilities, based on repeated information about migrants' return intentions. Our results suggest that educational investments in the son are positively associated with a higher probability of a permanent migration of the father. We also find that the son's permanent wages are positively associated with the probability of the father's permanent migration. Keywords: Intergenerational mobility, return intentions, educational investment, earnings.},
 author = {Dustmann, Christian},
 journal = {IZA Discussion Paper},
-title = {{{\{}R{\}}eturn {\{}M{\}}igration, {\{}I{\}}nvestment in {\{}C{\}}hildren and {\{}I{\}}ntergenerational {\{}M{\}}obility: {\{}C{\}}omparing {\{}S{\}}ons of {\{}F{\}}oreign and {\{}N{\}}ative {\{}B{\}}orn {\{}F{\}}athers}},
+title = {{Return Migration, Investment in Children and Intergenerational Mobility: Comparing Sons of Foreign and Native Born Fathers}},
 volume = {No. 3080},
 year = {2007}
 }
@@ -3732,7 +3732,7 @@ year = {2007}
 abstract = {This paper studies parental investment in education and intergenerational earnings mobility for father-son pairs with native and foreign born fathers. We illustrate within a simple model that for immigrants, investment in their children is related to their return migration probability. In our empirical analysis, we include a measure for return probabilities, based on repeated information about migrants' return intentions. Our results suggest that educational investments in the son are positively associated with a higher probability of a permanent migration of the father. We also find that the son's permanent wages are positively associated with the probability of the father's permanent migration. Keywords: Intergenerational mobility, return intentions, educational investment, earnings.},
 author = {Dustmann, Christian},
 journal = {IZA Discussion Paper},
-title = {{{\{}R{\}}eturn {\{}M{\}}igration, {\{}I{\}}nvestment in {\{}C{\}}hildren and {\{}I{\}}ntergenerational {\{}M{\}}obility: {\{}C{\}}omparing {\{}S{\}}ons of {\{}F{\}}oreign and {\{}N{\}}ative {\{}B{\}}orn {\{}F{\}}athers}},
+title = {{Return Migration, Investment in Children and Intergenerational Mobility: Comparing Sons of Foreign and Native Born Fathers}},
 volume = {No. 3080},
 year = {2007}
 }
@@ -3741,7 +3741,7 @@ author = {Dustmann, Christian},
 journal = {Oxford Economic Papers},
 number = {2},
 pages = {209--230},
-title = {{{\{}P{\}}arental {\{}B{\}}ackground, {\{}S{\}}econdary {\{}S{\}}chool {\{}T{\}}rack {\{}C{\}}hoice, and {\{}W{\}}ages}},
+title = {{Parental Background, Secondary School Track Choice, and Wages}},
 volume = {56},
 year = {2004}
 }
@@ -3749,7 +3749,7 @@ year = {2004}
 author = {Dustmann, Christian and Pereira, Sonia C},
 journal = {IZA Discussion Paper},
 number = {No. 1586},
-title = {{{\{}W{\}}age {\{}G{\}}rowth and {\{}J{\}}ob {\{}M{\}}obility in the {\{}U{\}}{\{}K{\}} and {\{}G{\}}ermany}},
+title = {{Wage Growth and Job Mobility in the UK and Germany}},
 year = {2005}
 }
 @article{Dustmann.2003,
@@ -3757,7 +3757,7 @@ author = {Dustmann, Christian and Rajah, Najma and van Soest, Arthur},
 journal = {Economic Journal},
 number = {485},
 pages = {99--120},
-title = {{{\{}C{\}}lass {\{}S{\}}ize,{\$}{\~{}}{\$}{\{}E{\}}ducation, and {\{}W{\}}ages}},
+title = {{Class Size, Education, and Wages}},
 volume = {113},
 year = {2003}
 }
@@ -3765,14 +3765,14 @@ year = {2003}
 address = {Cambridge, MA},
 author = {Dworkin, Robert},
 publisher = {Harvard University Press},
-title = {{{\{}A{\}}{\$}{\~{}}{\$}{\{}M{\}}atter of {\{}P{\}}rinciple}},
+title = {{A Matter of Principle}},
 year = {1986}
 }
 @book{Dworkin.1986,
 address = {Cambridge, MA},
 author = {Dworkin, Robert},
 publisher = {Harvard University Press},
-title = {{{\{}A{\}}{\$}{\~{}}{\$}{\{}M{\}}atter of {\{}P{\}}rinciple}},
+title = {{A Matter of Principle}},
 year = {1986}
 }
 @article{Dynarski.2000a,
@@ -3780,7 +3780,7 @@ author = {Dynarski, Susan},
 journal = {National Tax Journal},
 number = {3},
 pages = {629--662},
-title = {{{\{}H{\}}ope for {\{}W{\}}hom? {\{}F{\}}inancial {\{}A{\}}id for the {\{}M{\}}iddle {\{}C{\}}lass and {\{}I{\}}ts {\{}I{\}}mpact on {\{}C{\}}ollege {\{}A{\}}ttendance}},
+title = {{Hope for Whom? Financial Aid for the Middle Class and Its Impact on College Attendance}},
 volume = {53},
 year = {2000}
 }
@@ -3798,14 +3798,14 @@ author = {Dynarski, Susan},
 journal = {National Tax Journal},
 number = {3},
 pages = {629--662},
-title = {{{\{}H{\}}ope for {\{}W{\}}hom? {\{}F{\}}inancial {\{}A{\}}id for the {\{}M{\}}iddle {\{}C{\}}lass and {\{}I{\}}ts {\{}I{\}}mpact on {\{}C{\}}ollege {\{}A{\}}ttendance}},
+title = {{Hope for Whom? Financial Aid for the Middle Class and Its Impact on College Attendance}},
 volume = {53},
 year = {2000}
 }
 @article{Dynarski.2001,
 author = {Dynarski, Susan},
 journal = {Working Paper},
-title = {{{\{}D{\}}oes {\{}A{\}}id {\{}M{\}}atter? {\{}M{\}}easuring the {\{}E{\}}ffects of {\{}S{\}}tudent {\{}A{\}}id on {\{}C{\}}ollege {\{}A{\}}ttendance and {\{}C{\}}ompletion}},
+title = {{Does Aid Matter? Measuring the Effects of Student Aid on College Attendance and Completion}},
 volume = {Harvard Un},
 year = {2001}
 }
@@ -3836,7 +3836,7 @@ author = {Eide, Eric and Showalter, Mark},
 journal = {The Journal of Human Resources},
 number = {2},
 pages = {253--267},
-title = {{{\{}F{\}}actors {\{}A{\}}ffecting the {\{}T{\}}ransmission of {\{}E{\}}arnings {\{}A{\}}cross {\{}G{\}}enerations: {\{}A{\}} {\{}Q{\}}uantile {\{}R{\}}egression {\{}A{\}}pproach}},
+title = {{Factors Affecting the Transmission of Earnings Across Generations: A Quantile Regression Approach}},
 volume = {34},
 year = {1999}
 }
@@ -3899,7 +3899,7 @@ author = {Eisenhauer, Philipp and Heckman, James J and Vytlacil, Edward J},
 journal = {Journal of Political Economy},
 number = {2},
 pages = {413--443},
-title = {{{\{}T{\}}he {\{}G{\}}eneralized {\{}R{\}}oy {\{}M{\}}odel and the {\{}C{\}}ost-{\{}B{\}}enefit {\{}A{\}}nalysis of {\{}S{\}}ocial {\{}P{\}}rograms}},
+title = {{The Generalized Roy Model and the Cost-Benefit Analysis of Social Programs}},
 volume = {123},
 year = {2015}
 }
@@ -3928,7 +3928,7 @@ author = {Elder, Glen H and Caspi, Avshalom},
 journal = {Journal of Social Issues},
 number = {4},
 pages = {25--45},
-title = {{{\{}E{\}}conomic {\{}S{\}}tress in {\{}L{\}}ives:{\$}{\~{}}{\$}{\{}D{\}}evelopmental {\{}P{\}}erspectives}},
+title = {{Economic Stress in Lives: Developmental Perspectives}},
 volume = {44},
 year = {1988}
 }
@@ -3979,7 +3979,7 @@ author = {Engle, Robert F and Watson, Mark W},
 journal = {Journal of Econometrics},
 number = {3},
 pages = {385--400},
-title = {{{\{}A{\}}lternative {\{}A{\}}lgorithms for the {\{}E{\}}stimation of {\{}D{\}}ynamic {\{}F{\}}actor, {\{}M{\}}imic and {\{}V{\}}arying {\{}C{\}}oefficient {\{}R{\}}egression {\{}M{\}}odels}},
+title = {{Alternative Algorithms for the Estimation of Dynamic Factor, Mimic and Varying Coefficient Regression Models}},
 volume = {23},
 year = {1983}
 }
@@ -3988,7 +3988,7 @@ author = {Ensminger, Margaret E and Slusarcik, Anita L},
 journal = {Sociology of Education},
 number = {2},
 pages = {95--113},
-title = {{{\{}P{\}}ath to {\{}H{\}}igh {\{}S{\}}chool {\{}G{\}}raduation of {\{}D{\}}ropout:{\$}{\~{}}{\$}{\{}A{\}} {\{}L{\}}ongitudinal {\{}S{\}}tudy of a {\{}F{\}}irst {\{}G{\}}rade {\{}C{\}}ohort}},
+title = {{Path to High School Graduation of Dropout: A Longitudinal Study of a First Grade Cohort}},
 volume = {65},
 year = {1992}
 }
@@ -4081,7 +4081,7 @@ author = {Erikson, Robert and Goldthorpe, John H},
 journal = {The Journal of Economic Perspectives},
 number = {3},
 pages = {31--44},
-title = {{{\{}I{\}}ntergenerational {\{}I{\}}nequality: {\{}A{\}} {\{}S{\}}ociological {\{}P{\}}erspective}},
+title = {{Intergenerational Inequality: A Sociological Perspective}},
 volume = {16},
 year = {2002}
 }
@@ -4089,17 +4089,17 @@ year = {2002}
 address = {Boulder, CO},
 editor = {Erikson, Robert and Jonsson, Jan O},
 publisher = {Westview Press},
-title = {{{\{}C{\}}an {\{}E{\}}ducation be {\{}E{\}}qualized? {\{}T{\}}he {\{}S{\}}wedish {\{}C{\}}ase in {\{}C{\}}omparative {\{}P{\}}erspective}},
+title = {{Can Education be Equalized? The Swedish Case in Comparative Perspective}},
 year = {1996}
 }
 @incollection{Erikson.1996,
 address = {Boulder, CO},
 author = {Erikson, Robert and Jonsson, Jan O},
-booktitle = {{\{}C{\}}an {\{}E{\}}ducation be {\{}E{\}}qualized? {\{}T{\}}he {\{}S{\}}wedish {\{}C{\}}ase in {\{}C{\}}omparative {\{}P{\}}erspective},
+booktitle = {Can Education be Equalized? The Swedish Case in Comparative Perspective},
 editor = {Erikson, Robert and Jonsson, Jan O},
 pages = {1--64},
 publisher = {Westview Press},
-title = {{{\{}E{\}}xplaining {\{}C{\}}lass {\{}I{\}}nequality in {\{}E{\}}ducatioln: {\{}T{\}}he {\{}S{\}}wedish {\{}T{\}}est {\{}C{\}}ase}},
+title = {{Explaining Class Inequality in Educatioln: The Swedish Test Case}},
 year = {1996}
 }
 @article{Ermisch.2006,
@@ -4107,7 +4107,7 @@ author = {Ermisch, John and Francesconi, Marco and Sieder, Thomas},
 journal = {The Economic Journal},
 number = {513},
 pages = {659--679},
-title = {{{\{}I{\}}ntergenerational {\{}M{\}}obility and {\{}M{\}}artial {\{}S{\}}orting}},
+title = {{Intergenerational Mobility and Martial Sorting}},
 volume = {116},
 year = {2006}
 }
@@ -4116,7 +4116,7 @@ author = {Escobar, Michael D and West, Mike},
 journal = {Journal of the American Statistical Association},
 number = {460},
 pages = {577--588},
-title = {{Bayesian Density Estimation and Inference {\{}U{\}}sing Mixtures}},
+title = {{Bayesian Density Estimation and Inference Using Mixtures}},
 volume = {90},
 year = {1995}
 }
@@ -4148,7 +4148,7 @@ year = {1971}
 @article{Fahrmeir.2006,
 author = {Fahrmeir, Ludwig and Raach, Alexander},
 journal = {Working Paper},
-title = {{{\{}A{\}} {\{}B{\}}ayesian {\{}S{\}}emiparametric {\{}L{\}}atent {\{}V{\}}ariable {\{}M{\}}odel for {\{}M{\}}ixed {\{}R{\}}esponses}},
+title = {{A Bayesian Semiparametric Latent Variable Model for Mixed Responses}},
 volume = {University},
 year = {2006}
 }
@@ -4165,30 +4165,30 @@ year = {2009}
 author = {Farkas, George},
 journal = {Annual Review of Sociology},
 pages = {541--562},
-title = {{{\{}C{\}}ognitive{\$}{\~{}}{\$}{\{}S{\}}kills and {\{}N{\}}oncognitive {\{}B{\}}ehaviors in {\{}S{\}}tratification {\{}P{\}}rocesses}},
+title = {{Cognitive Skills and Noncognitive Behaviors in Stratification Processes}},
 volume = {29},
 year = {2003}
 }
 @book{Felitti.2005,
 author = {Felitti, Vincent J and Anda, Robert F},
 publisher = {Centers for Disease Control and Kaiser Permanente},
-title = {{{\{}T{\}}he {\{}A{\}}dverse {\{}C{\}}hildhood {\{}E{\}}xperiences ({\{}A{\}}{\{}C{\}}{\{}E{\}}) {\{}S{\}}tudy}},
+title = {{The Adverse Childhood Experiences (ACE) Study}},
 year = {2005}
 }
 @incollection{Ferguson.1983,
 address = {New York, NY},
 author = {Ferguson, T S},
-booktitle = {{\{}R{\}}ecent {\{}A{\}}dvances in {\{}S{\}}tatistics},
+booktitle = {Recent Advances in Statistics},
 editor = {Rizvi, M H and Chernoff, Herman},
 pages = {287--302},
 publisher = {Academic Press},
-title = {{{\{}B{\}}ayesian {\{}D{\}}ensity {\{}E{\}}stimation by {\{}M{\}}ixtures of {\{}N{\}}ormal {\{}D{\}}istributions}},
+title = {{Bayesian Density Estimation by Mixtures of Normal Distributions}},
 year = {1983}
 }
 @article{Fields.2007,
 author = {Fields, Gary S and Duval-Hern{\'{a}}ndez, Robert and Freije, Samuel and {S{\`{a}}nchez Puerta}, Maria Laura},
 journal = {IZA Discussion Paper},
-title = {{{\{}E{\}}arnings {\{}M{\}}obility in {\{}A{\}}rgentina, {\{}M{\}}exico and {\{}V{\}}enezuela: {\{}T{\}}esting the {\{}D{\}}ivergence of {\{}E{\}}arnings and the {\{}S{\}}ymmetry of {\{}M{\}}obility {\{}H{\}}ypotheses}},
+title = {{Earnings Mobility in Argentina, Mexico and Venezuela: Testing the Divergence of Earnings and the Symmetry of Mobility Hypotheses}},
 volume = {No. 3184},
 year = {2007}
 }
@@ -4204,7 +4204,7 @@ author = {Finkelstein, Eric A and Fiebelkorn, Ian C and Wang, Guijing},
 journal = {Health Affairs},
 number = {W3},
 pages = {219--225},
-title = {{{\{}N{\}}ational{\$}{\~{}}{\$}{\{}M{\}}edical {\{}S{\}}pending {\{}A{\}}ttributable to{\$}{\~{}}{\$}{\{}O{\}}verweight and {\{}O{\}}besity:{\$}{\~{}}{\$}{\{}H{\}}ow much, and who`s {\{}P{\}}aying}},
+title = {{National Medical Spending Attributable to Overweight and Obesity: How much, and who`s Paying}},
 volume = {Web Exclus},
 year = {2003}
 }
@@ -4221,14 +4221,14 @@ year = {2007}
 address = {Dordrecht, NL},
 author = {Fisher, Paul},
 publisher = {Kluwer},
-title = {{{\{}R{\}}ational {\{}E{\}}xpectaions in {\{}M{\}}acroeconomic {\{}M{\}}odels}},
+title = {{Rational Expectaions in Macroeconomic Models}},
 year = {1992}
 }
 @book{Fisher.1992,
 address = {Dordrecht, NL},
 author = {Fisher, Paul},
 publisher = {Kluwer},
-title = {{{\{}R{\}}ational {\{}E{\}}xpectaions in {\{}M{\}}acroeconomic {\{}M{\}}odels}},
+title = {{Rational Expectaions in Macroeconomic Models}},
 year = {1992}
 }
 @article{Fisher.1922,
@@ -4256,7 +4256,7 @@ author = {Flegal, Katherine M and Graubard, Barry I and Williamson, David F and 
 journal = {Journal of American Medical Association},
 number = {17},
 pages = {2028--2037},
-title = {{{\{}C{\}}ause-{\{}S{\}}pecific {\{}E{\}}xcess {\{}D{\}}eaths {\{}A{\}}ssociated with {\{}U{\}}nderweight, {\{}O{\}}verweight, and {\{}O{\}}besity}},
+title = {{Cause-Specific Excess Deaths Associated with Underweight, Overweight, and Obesity}},
 volume = {298},
 year = {2007}
 }
@@ -4281,18 +4281,18 @@ year = {2008}
 @article{Flossmann.2007,
 author = {Flossmann, Anton L and Piatek, R{\`{e}}mi and Wichert, Laura},
 journal = {Working Paper},
-title = {{{\{}G{\}}oing {\{}B{\}}eyond {\{}R{\}}eturns to {\{}E{\}}ducation: {\{}T{\}}he {\{}R{\}}ole of {\{}N{\}}oncognitive {\{}S{\}}kills on {\{}W{\}}ages in {\{}G{\}}ermany}},
+title = {{Going Beyond Returns to Education: The Role of Noncognitive Skills on Wages in Germany}},
 volume = {University},
 year = {2007}
 }
 @incollection{Fogel.1997,
 address = {Amsterdam, NL},
 author = {Fogel, Robert W},
-booktitle = {{\{}H{\}}andbook of {\{}P{\}}opulation and {\{}F{\}}amily {\{}E{\}}conomics},
+booktitle = {Handbook of Population and Family Economics},
 editor = {Rosenzweig, Mark R and Stark, Oded},
 pages = {433--481},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}N{\}}ew {\{}F{\}}indings on {\{}S{\}}ecular {\{}T{\}}rends in {\{}N{\}}utrition and {\{}M{\}}ortality:{\$}{\~{}}{\$}{\{}S{\}}ome {\{}I{\}}mplications for {\{}P{\}}opulation {\{}T{\}}heory}},
+title = {{New Findings on Secular Trends in Nutrition and Mortality: Some Implications for Population Theory}},
 volume = {1A},
 year = {1997}
 }
@@ -4300,7 +4300,7 @@ year = {1997}
 address = {Cambridge, UK},
 author = {Fogel, Robert W},
 publisher = {Cambridge University Press},
-title = {{{\{}T{\}}he {\{}E{\}}scape from {\{}H{\}}unger and {\{}P{\}}remature {\{}D{\}}eath, 1700-2100, {\{}E{\}}urope, {\{}A{\}}merica, and the {\{}T{\}}hird {\{}W{\}}orld}},
+title = {{The Escape from Hunger and Premature Death, 1700-2100, Europe, America, and the Third World}},
 year = {2004}
 }
 @article{Fortin.2008,
@@ -4308,14 +4308,14 @@ author = {Fortin, Nicole M},
 journal = {The Journal of Human Resources},
 number = {4},
 pages = {884--918},
-title = {{{\{}T{\}}he {\{}G{\}}ender {\{}W{\}}age {\{}G{\}}ap among {\{}Y{\}}oung {\{}A{\}}dults in the {\{}U{\}}nited {\{}S{\}}tates:{\$}{\~{}}{\$}{\{}T{\}}he {\{}I{\}}mportance of {\{}M{\}}oney versus {\{}P{\}}eople}},
+title = {{The Gender Wage Gap among Young Adults in the United States: The Importance of Money versus People}},
 volume = {43},
 year = {2008}
 }
 @incollection{Fortin.2011,
 address = {Amsterdam, Netherlands},
 author = {Fortin, Nicole and Lemieux, Thomas and Firpo, Sergio},
-booktitle = {{\{}H{\}}andbook of {\{}L{\}}abor {\{}E{\}}conomics},
+booktitle = {Handbook of Labor Economics},
 editor = {Ashenfelter, Orley and Card, David},
 pages = {1--102},
 publisher = {Elsevier Science},
@@ -4347,7 +4347,7 @@ year = {2006}
 @article{Francesconi.2007,
 author = {Francesconi, Marco},
 journal = {IZA Discussion Paper},
-title = {{{\{}A{\}}dult {\{}O{\}}utcomes for {\{}C{\}}hildren of {\{}T{\}}eenage {\{}M{\}}others}},
+title = {{Adult Outcomes for Children of Teenage Mothers}},
 volume = {No. 2778},
 year = {2007}
 }
@@ -4356,7 +4356,7 @@ author = {Franz, Wolfgang and Pfeiffer, Friedhelm},
 journal = {Labour Economics},
 number = {2},
 pages = {255--284},
-title = {{{\{}R{\}}easons for {\{}W{\}}age {\{}R{\}}igidites in {\{}G{\}}ermany}},
+title = {{Reasons for Wage Rigidites in Germany}},
 volume = {20},
 year = {2006}
 }
@@ -4374,13 +4374,13 @@ author = {Frederick, Shane},
 journal = {Journal of Economic Perspectives},
 number = {4},
 pages = {25--42},
-title = {{{\{}C{\}}ognitive {\{}R{\}}eflection and {\{}D{\}}ecision {\{}M{\}}aking}},
+title = {{Cognitive Reflection and Decision Making}},
 volume = {19},
 year = {2005}
 }
 @article{Fredrikkson.2008,
 author = {Fredrikkson, P and Johansson, P},
-journal = {Journal of Business {\&} Economic Statistics},
+journal = {Journal of Business \& Economic Statistics},
 number = {4},
 pages = {435--445},
 title = {{Dynamic Treatment Assignment: The Consequences for Observational Data}},
@@ -4436,7 +4436,7 @@ year = {2011}
 address = {Princeton, NJ},
 author = {Friedman, Milton},
 publisher = {Princeton University Press},
-title = {{{\{}A{\}} {\{}T{\}}heory of the {\{}C{\}}onsumption {\{}F{\}}unction}},
+title = {{A Theory of the Consumption Function}},
 year = {1957}
 }
 @book{Friedman.1966,
@@ -4449,12 +4449,12 @@ year = {1966}
 author = {Froelich, Markus},
 journal = {Econometrics Journal},
 pages = {540--551},
-title = {{{\{}N{\}}on-parametric {\{}R{\}}egression for {\{}B{\}}inary {\{}D{\}}ependent {\{}V{\}}ariables}},
+title = {{Non-parametric Regression for Binary Dependent Variables}},
 volume = {9},
 year = {2006}
 }
 @article{Frolich2010,
-author = {Fr{\"{o}}lich, Markus},
+author = {Fr\"{o}lich, Markus},
 doi = {10.1198/jasa.2010.ap08148},
 issn = {0162-1459},
 journal = {Journal of the American Statistical Association},
@@ -4468,7 +4468,7 @@ volume = {105},
 year = {2010}
 }
 @article{Frolich2006,
-author = {Fr{\"{o}}lich, Markus},
+author = {Fr\"{o}lich, Markus},
 doi = {10.1111/j.1368-423X.2006.00196.x},
 issn = {1368-4221},
 journal = {The Econometrics Journal},
@@ -4482,7 +4482,7 @@ volume = {9},
 year = {2006}
 }
 @article{Frolich.2008,
-author = {Fr{\"{o}}lich, Markus},
+author = {Fr\"{o}lich, Markus},
 journal = {Journal of the American Statistical Association},
 number = {482},
 pages = {547--558},
@@ -4491,13 +4491,13 @@ volume = {103},
 year = {2008}
 }
 @article{Froelich.2010,
-author = {Fr{\"{o}}lich, Markus and Lechner, Michael},
+author = {Fr\"{o}lich, Markus and Lechner, Michael},
 journal = {Journal of the American Statistical Association},
 title = {{Exploiting Regional Treatment Intensity for the Evaluation of Labor Market Policies}},
 year = {2010}
 }
 @article{Frolich.2003,
-author = {Fr{\"{o}}lich, Markus and Lechner, Michael and Steiger, Heidi},
+author = {Fr\"{o}lich, Markus and Lechner, Michael and Steiger, Heidi},
 journal = {Swiss Journal of Economics and Statistics},
 number = {3},
 pages = {311--331},
@@ -4510,7 +4510,7 @@ author = {Fryer, Roland G and Levitt, Steven D},
 journal = {American Economic Journal: Applied Economics},
 number = {2},
 pages = {210--240},
-title = {{{\{}A{\}}n {\{}E{\}}mpirical {\{}A{\}}nalysis of the {\{}G{\}}ender {\{}G{\}}ap in {\{}M{\}}athematics}},
+title = {{An Empirical Analysis of the Gender Gap in Mathematics}},
 volume = {2},
 year = {2010}
 }
@@ -4519,7 +4519,7 @@ author = {Fryer, Roland G and Levitt, Steven D},
 journal = {The Review of Economics and Statistics},
 number = {2},
 pages = {447--464},
-title = {{{\{}U{\}}nderstanding the {\{}B{\}}lack-{\{}W{\}}hite {\{}T{\}}est {\{}S{\}}core {\{}G{\}}ap in the {\{}F{\}}irst {\{}T{\}}wo {\{}Y{\}}ears of {\{}S{\}}chool}},
+title = {{Understanding the Black-White Test Score Gap in the First Two Years of School}},
 volume = {86},
 year = {2004}
 }
@@ -4527,7 +4527,7 @@ year = {2004}
 author = {Fryer, Roland G and Levitt, Steven D},
 journal = {NBER Working Paper},
 pages = {No. 11049},
-title = {{{\{}T{\}}he {\{}B{\}}lack-{\{}W{\}}hite {\{}T{\}}est {\{}S{\}}core {\{}G{\}}ap {\{}T{\}}hrough {\{}T{\}}hird {\{}G{\}}rade}},
+title = {{The Black-White Test Score Gap Through Third Grade}},
 year = {2005}
 }
 @article{Fu.2015,
@@ -4539,21 +4539,21 @@ year = {2015}
 @incollection{Fuchs.1990,
 address = {Milwaukee, WI},
 author = {Fuchs, Victor},
-booktitle = {{\{}R{\}}ebuilding the {\{}N{\}}est: {\{}A{\}} {\{}N{\}}ew {\{}C{\}}ommitment to {\{}A{\}}merican {\{}F{\}}amily},
+booktitle = {Rebuilding the Nest: A New Commitment to American Family},
 editor = {Blankenhorn, David and Bayme, Steven and Elshtain, Jean B},
 publisher = {Family Service America},
-title = {{{\{}A{\}}re {\{}A{\}}mericans {\{}U{\}}nderinvesting in {\{}T{\}}heir {\{}C{\}}hildren}},
+title = {{Are Americans Underinvesting in Their Children}},
 year = {1990}
 }
 @article{Fuchs.1982,
 author = {Fuchs, Victor R},
 journal = {NBER Working Paper},
 number = {539},
-title = {{{\{}T{\}}ime {\{}P{\}}reference and {\{}H{\}}ealth}},
+title = {{Time Preference and Health}},
 year = {1982}
 }
 @article{FuchsSchundeln.2008,
-author = {Fuchs-Sch{\"{u}}ndeln, Nicola},
+author = {Fuchs-Sch\"{u}ndeln, Nicola},
 doi = {10.1257/aer.98.5.1798},
 issn = {0002-8282},
 journal = {American Economic Review},
@@ -4652,15 +4652,15 @@ author = {Gelfand, Alan E and Smith, Adrian F},
 journal = {Journal of the American Statistical Association},
 number = {410},
 pages = {398--409},
-title = {{{\{}S{\}}ampling-{\{}B{\}}ases {\{}A{\}}pproaches to {\{}C{\}}alculating {\{}M{\}}arginal {\{}D{\}}ensities}},
+title = {{Sampling-Bases Approaches to Calculating Marginal Densities}},
 volume = {85},
 year = {1990}
 }
 @book{Gelman.2003,
 address = {New York, NY},
 author = {Gelman, Andrew and Carlin, John B and Stern, Hal S},
-publisher = {Chapman{\&}Hall},
-title = {{{\{}B{\}}ayesian {\{}D{\}}ata {\{}A{\}}nalysis}},
+publisher = {Chapman&Hall},
+title = {{Bayesian Data Analysis}},
 year = {2003}
 }
 @article{Genest.1993,
@@ -4668,7 +4668,7 @@ author = {Genest, Christian and Rivest, Louis-Paul},
 journal = {Journal of the American Statistical Association},
 number = {423},
 pages = {1034--1043},
-title = {{{\{}S{\}}tatistical {\{}I{\}}nference {\{}P{\}}rocedures for {\{}B{\}}ivariate {\{}A{\}}rchimedian {\{}C{\}}opulas}},
+title = {{Statistical Inference Procedures for Bivariate Archimedian Copulas}},
 volume = {88},
 year = {1993}
 }
@@ -4677,14 +4677,14 @@ author = {Gennetian, Lisa A},
 journal = {Journal of Population Economics},
 number = {3},
 pages = {415--436},
-title = {{{\{}O{\}}ne or {\{}T{\}}wo {\{}P{\}}arents?{\$}{\~{}}{\$}{\{}H{\}}alf of {\{}S{\}}tep {\{}S{\}}ibling? {\{}T{\}}he {\{}E{\}}ffect of {\{}F{\}}amily {\{}S{\}}tructure on {\{}Y{\}}oung {\{}C{\}}hildren's {\{}A{\}}chievement}},
+title = {{One or Two Parents? Half of Step Sibling? The Effect of Family Structure on Young Children's Achievement}},
 volume = {18},
 year = {2005}
 }
 @article{Gensowski.2010,
 author = {Gensowski, Miriam and Heckman, James and Savelyev, Peter},
 journal = {Working Paper},
-title = {{{\{}T{\}}he {\{}R{\}}ate of {\{}R{\}}eturn to {\{}E{\}}ducation based on a {\{}C{\}}omplete {\{}W{\}}ork {\{}H{\}}istory of {\{}H{\}}igh-{\{}A{\}}bility {\{}I{\}}nidividuals}},
+title = {{The Rate of Return to Education based on a Complete Work History of High-Ability Inidividuals}},
 volume = {University},
 year = {2011}
 }
@@ -4695,7 +4695,7 @@ title = {{The Recomputation Manifesto}},
 year = {2013}
 }
 @article{George2010,
-abstract = {The Speech Transmission Index (STI; Houtgast, Steeneken, {\&} Plomp, 1980; Steeneken {\&} Houtgast, 1980) is commonly used to quantify the adverse effects of reverberation and stationary noise on speech intelligibility for normal-hearing listeners. Duquesnoy and Plomp (1980) showed that the STI can be applied for presbycusic listeners, relating speech reception thresholds (SRTs) in various reverberant conditions to a fixed, subject-dependent STI value. The current study aims at extending their results to a wider range of hearing-impaired listeners.},
+abstract = {The Speech Transmission Index (STI; Houtgast, Steeneken, \& Plomp, 1980; Steeneken \& Houtgast, 1980) is commonly used to quantify the adverse effects of reverberation and stationary noise on speech intelligibility for normal-hearing listeners. Duquesnoy and Plomp (1980) showed that the STI can be applied for presbycusic listeners, relating speech reception thresholds (SRTs) in various reverberant conditions to a fixed, subject-dependent STI value. The current study aims at extending their results to a wider range of hearing-impaired listeners.},
 author = {George, Erwin L J and Goverts, S Theo and Festen, Joost M and Houtgast, Tammo},
 doi = {10.1044/1092-4388(2010/09-0197)},
 issn = {1558-9102},
@@ -4718,18 +4718,18 @@ year = {2002}
 }
 @article{Gernandt.2006,
 author = {Gernandt, Johannes and Pfeiffer, Friedhelm},
-journal = {Jahrb{\"{u}}cher f{\"{u}}r National{\"{o}}konomie und Statistik},
+journal = {Jahrb\"{u}cher f\"{u}r National\"{o}konomie und Statistik},
 number = {4},
 pages = {in print},
-title = {{{\{}R{\}}ising {\{}W{\}}age {\{}I{\}}nequality in {\{}G{\}}ermany}},
+title = {{Rising Wage Inequality in Germany}},
 volume = {227},
 year = {2007}
 }
 @book{Geweke.2005,
 address = {Hoboken, NJ},
 author = {Geweke, John},
-publisher = {John Wiley {\&}{\$}{\~{}}{\$}Sons},
-title = {{{\{}C{\}}ontemporary {\{}B{\}}ayesian {\{}E{\}}conometrics and {\{}S{\}}tatistics}},
+publisher = {John Wiley \& Sons},
+title = {{Contemporary Bayesian Econometrics and Statistics}},
 year = {2005}
 }
 @article{Geweke.1999a,
@@ -4741,18 +4741,18 @@ year = {1999}
 @article{Geweke.1997,
 author = {Geweke, John and Keane, Michael P},
 journal = {Federal Reserve Bank of Minneapolis Economic Perspectives},
-title = {{{\{}M{\}}ixture of {\{}N{\}}ormals {\{}P{\}}robit}},
+title = {{Mixture of Normals Probit}},
 volume = {237},
 year = {1997}
 }
 @incollection{Geweke.1999,
 address = {Cambridge, MA},
 author = {Geweke, John and Keane, Michael P},
-booktitle = {{\{}A{\}}nalysis of {\{}P{\}}anels and {\{}L{\}}imited {\{}D{\}}ependent {\{}V{\}}ariable {\{}M{\}}odels in {\{}H{\}}onour of {\{}G{\}}. {\{}S{\}}. {\{}M{\}}addala},
+booktitle = {Analysis of Panels and Limited Dependent Variable Models in Honour of G. S. Maddala},
 editor = {Hsiao, Cheng and Maddala, Gangadharro S},
 pages = {49--79},
 publisher = {Cambridge University Press},
-title = {{{\{}M{\}}ixture of {\{}N{\}}ormals {\{}P{\}}robit {\{}M{\}}odels}},
+title = {{Mixture of Normals Probit Models}},
 year = {1999}
 }
 @article{Ghaoui.1998,
@@ -4768,14 +4768,14 @@ year = {2008}
 address = {New York, NY},
 editor = {Gilbert, Daniel T and Fiske, Susan T and Lindzey, Gardner},
 publisher = {Oxford University Press},
-title = {{{\{}T{\}}he {\{}H{\}}andbook of {\{}S{\}}ocial {\{}P{\}}sychology}},
+title = {{The Handbook of Social Psychology}},
 year = {1998}
 }
 @book{Gilbert.1998a,
 address = {New York, NY},
 editor = {Gilbert, Daniel T and Fiske, Susan T and Lindzey, Gardner},
 publisher = {Oxford University Press},
-title = {{{\{}T{\}}he {\{}H{\}}andbook of {\{}S{\}}ocial {\{}P{\}}sychology}},
+title = {{The Handbook of Social Psychology}},
 year = {1998}
 }
 @article{Gilboa.1993,
@@ -4828,8 +4828,8 @@ year = {1989}
 @book{Gilks.1996,
 address = {New York, NY},
 editor = {Gilks, W R and Richardson, S and Spiegelhalter, D J},
-publisher = {Chapman {\&} Hall},
-title = {{{\{}M{\}}arkov {\{}C{\}}hain {\{}M{\}}onte {\{}C{\}}arlo in {\{}P{\}}ractice}},
+publisher = {Chapman \& Hall},
+title = {{Markov Chain Monte Carlo in Practice}},
 year = {1996}
 }
 @article{Ginsburg.2008,
@@ -4845,7 +4845,7 @@ author = {Ginther, Donna K and Pollak, Robert A},
 journal = {Demography},
 number = {6},
 pages = {671--696},
-title = {{{\{}F{\}}amily {\{}S{\}}tructure and {\{}C{\}}hildren's {\{}E{\}}ducational {\{}O{\}}utcomes}},
+title = {{Family Structure and Children's Educational Outcomes}},
 volume = {41},
 year = {2004}
 }
@@ -4853,7 +4853,7 @@ year = {2004}
 address = {Cambridge, UK},
 author = {Gluckman, Peter D and Hanson, Mark},
 publisher = {Cambridge University Press},
-title = {{{\{}T{\}}he {\{}F{\}}etal {\{}M{\}}atrix:{\$}{\~{}}{\$}{\{}E{\}}volution, {\{}D{\}}evelopment, and {\{}D{\}}isease}},
+title = {{The Fetal Matrix: Evolution, Development, and Disease}},
 year = {2005}
 }
 @article{Goffe1994,
@@ -4868,7 +4868,7 @@ author = {Goldberger, Arthur S},
 journal = {American Economic Review},
 number = {3},
 pages = {504--513},
-title = {{{\{}E{\}}conomic and {\{}M{\}}echanical {\{}M{\}}odels of {\{}I{\}}ntergenerational {\{}T{\}}ransmission}},
+title = {{Economic and Mechanical Models of Intergenerational Transmission}},
 volume = {79},
 year = {1989}
 }
@@ -4877,7 +4877,7 @@ author = {Goldberger, Arthur S},
 journal = {Journal of Econometrics},
 number = {3},
 pages = {357--366},
-title = {{{\{}L{\}}inear {\{}R{\}}egression {\{}A{\}}fter {\{}S{\}}election}},
+title = {{Linear Regression After Selection}},
 volume = {15},
 year = {1981}
 }
@@ -4886,7 +4886,7 @@ author = {Goldberger, Arthur S},
 journal = {International Economic Review},
 number = {1},
 pages = {1--15},
-title = {{{\{}M{\}}aximum-{\{}L{\}}ikelihood {\{}E{\}}stimation of {\{}R{\}}egressions {\{}C{\}}ontaining {\{}U{\}}nobservable {\{}I{\}}ndependent {\{}V{\}}ariables}},
+title = {{Maximum-Likelihood Estimation of Regressions Containing Unobservable Independent Variables}},
 volume = {13},
 year = {1972}
 }
@@ -4895,7 +4895,7 @@ author = {Goldberger, Arthur S},
 journal = {Psychometrika},
 number = {2},
 pages = {83--107},
-title = {{{\{}E{\}}conometrics and {\{}P{\}}sychometrics:{\$}{\~{}}{\$}{\{}A{\}} {\{}S{\}}urvey of {\{}C{\}}ommunalities}},
+title = {{Econometrics and Psychometrics: A Survey of Communalities}},
 volume = {36},
 year = {1971}
 }
@@ -4904,37 +4904,37 @@ author = {Goldberger, Arthur S},
 journal = {Econometrica},
 number = {6},
 pages = {979--1001},
-title = {{{\{}S{\}}tructural {\{}E{\}}quation {\{}M{\}}odels in the {\{}S{\}}ocial {\{}S{\}}ciences}},
+title = {{Structural Equation Models in the Social Sciences}},
 volume = {40},
 year = {1972}
 }
 @incollection{Goldberger.1974,
 address = {New York, NY},
 author = {Goldberger, Arthur S},
-booktitle = {{\{}F{\}}rontiers in {\{}E{\}}conometrics},
+booktitle = {Frontiers in Econometrics},
 editor = {Zarembka, Paul},
 publisher = {Academic Press},
-title = {{{\{}U{\}}nobservable {\{}V{\}}ariables in {\{}E{\}}conometrics}},
+title = {{Unobservable Variables in Econometrics}},
 year = {1974}
 }
 @book{Goldberger.1973,
 address = {New York, NY},
 author = {Goldberger, Arthur S and Duncan, Otis D},
 publisher = {Seminar Press},
-title = {{{\{}S{\}}tructural {\{}E{\}}quation {\{}M{\}}odels in {\{}S{\}}ocial {\{}S{\}}cience}},
+title = {{Structural Equation Models in Social Science}},
 year = {1973}
 }
 @article{Goldin.2007,
 author = {Goldin, Claudia and Katz, Lawrence F},
 journal = {NBER Working Paper},
-title = {{{\{}L{\}}ong-{\{}R{\}}un {\{}C{\}}hanges in the {\{}U{\}}.{\{}S{\}}. {\{}W{\}}age {\{}S{\}}tructure: {\{}N{\}}arrowing, {\{}W{\}}idening, {\{}P{\}}olarizing}},
+title = {{Long-Run Changes in the U.S. Wage Structure: Narrowing, Widening, Polarizing}},
 volume = {13568},
 year = {2007}
 }
 @article{Goldthorpe.2008,
 author = {Goldthorpe, John H and Mills, Colin},
 journal = {Unpublished Manuscript},
-title = {{{\{}T{\}}rends in {\{}I{\}}ntergenerational {\{}C{\}}lass {\{}M{\}}obility in {\{}M{\}}odern {\{}B{\}}ritain: {\{}E{\}}vidence from {\{}N{\}}ational {\{}S{\}}urveys, 1972-2005 {\{}E{\}}{\{}V{\}}{\{}I{\}}{\{}D{\}}{\{}E{\}}{\{}N{\}}{\{}C{\}}{\{}E{\}} {\{}F{\}}{\{}R{\}}{\{}O{\}}{\{}M{\}} {\{}N{\}}{\{}A{\}}{\{}T{\}}{\{}I{\}}{\{}O{\}}{\{}N{\}}{\{}A{\}}{\{}L{\}} {\{}S{\}}{\{}U{\}}{\{}R{\}}{\{}V{\}}{\{}E{\}}{\{}Y{\}}{\{}S{\}}, 1972-2005}},
+title = {{Trends in Intergenerational Class Mobility in Modern Britain: Evidence from National Surveys, 1972-2005 EVIDENCE FROM NATIONAL SURVEYS, 1972-2005}},
 year = {2008}
 }
 @article{Gottfredson.1997,
@@ -4959,7 +4959,7 @@ author = {Gottschalk, Peter and Moffitt, Robert},
 journal = {Brookings Papers on Economic Activity},
 number = {2},
 pages = {217--254},
-title = {{{\{}T{\}}he {\{}G{\}}rowth of {\{}E{\}}arnings {\{}I{\}}nstability in the {\{}U{\}}.{\{}S{\}}. {\{}L{\}}abor {\{}M{\}}arket}},
+title = {{The Growth of Earnings Instability in the U.S. Labor Market}},
 volume = {1994},
 year = {1994}
 }
@@ -4973,14 +4973,14 @@ year = {1984}
 address = {Princeton, NJ},
 author = {Gourieroux, Christian and Jasiak, Joann},
 publisher = {Princeton University Press},
-title = {{{\{}F{\}}inancial {\{}E{\}}conometrics}},
+title = {{Financial Econometrics}},
 year = {2001}
 }
 @book{Gourieroux.1997,
 address = {Cambridge, MA},
 author = {Gourieroux, Christian and Monfort, Alain},
 publisher = {Cambridge University Press},
-title = {{{\{}T{\}}ime {\{}S{\}}eries and {\{}D{\}}ynamic {\{}M{\}}odels}},
+title = {{Time Series and Dynamic Models}},
 year = {1997}
 }
 @article{Gourieroux.1993,
@@ -4996,7 +4996,7 @@ year = {1993}
 address = {Oxford, United Kingdom},
 author = {Gourieroux, Christian and Monfort, Alain},
 publisher = {Oxford University Press},
-title = {{{\{}S{\}}imulation-{\{}B{\}}ased {\{}E{\}}conometrics}},
+title = {{Simulation-Based Econometrics}},
 year = {1996}
 }
 @article{Gourieroux.1993a,
@@ -5051,7 +5051,7 @@ address = {Boulder, CO},
 edition = {2},
 editor = {Granovetter, Mark and Swedberg, Richard},
 publisher = {Westview Press},
-title = {{{\{}T{\}}he {\{}S{\}}ociology of {\{}E{\}}conomic {\{}L{\}}ife}},
+title = {{The Sociology of Economic Life}},
 year = {2001}
 }
 @article{Grawe.2006,
@@ -5059,7 +5059,7 @@ author = {Grawe, Nathan D},
 journal = {Labour Economics},
 number = {5},
 pages = {551--570},
-title = {{{\{}L{\}}ifecycle {\{}B{\}}ias in {\{}E{\}}stimates of {\{}I{\}}ntergenerational {\{}E{\}}arnings {\{}P{\}}ersistence}},
+title = {{Lifecycle Bias in Estimates of Intergenerational Earnings Persistence}},
 volume = {13},
 year = {2006}
 }
@@ -5068,7 +5068,7 @@ author = {Grawe, Nathan D and Mulligan, Casey B},
 journal = {Journal of Economic Perspectives},
 number = {3},
 pages = {45--58},
-title = {{{\{}E{\}}conomic {\{}I{\}}nterpretations of {\{}I{\}}ntergenerational {\{}C{\}}orrelations}},
+title = {{Economic Interpretations of Intergenerational Correlations}},
 volume = {16},
 year = {2002}
 }
@@ -5076,28 +5076,28 @@ year = {2002}
 address = {Upper Saddle River, N.J.},
 author = {Green, William H},
 publisher = {Prentice Hall},
-title = {{{\{}E{\}}conometric {\{}A{\}}nalyis}},
+title = {{Econometric Analyis}},
 year = {2003}
 }
 @book{Gresham.1990,
 address = {Circle Pines, MN},
 author = {Gresham, Frank M and Elliot, Stephen N},
 publisher = {American Guidance Service},
-title = {{{\{}S{\}}ocial {\{}S{\}}kills {\{}R{\}}ating {\{}S{\}}ystem}},
+title = {{Social Skills Rating System}},
 year = {1990}
 }
 @book{Griliches.1983,
 address = {Amsterdam, NL},
 editor = {Griliches, Zvi and Intriligator, Michael D},
 publisher = {Elsevier Science},
-title = {{{\{}H{\}}andbook of {\{}E{\}}conometrics}},
+title = {{Handbook of Econometrics}},
 year = {1983}
 }
 @book{Griliches.1984,
 address = {Amsterdam, NL},
 editor = {Griliches, Zvi and Intriligator, Michael D},
 publisher = {Elsevier Science},
-title = {{{\{}H{\}}andbook of {\{}E{\}}conometrics,{\$}{\~{}}{\$}{\{}V{\}}olume {\{}I{\}}{\{}I{\}}}},
+title = {{Handbook of Econometrics, Volume II}},
 year = {1984}
 }
 @article{Gronau.1974,
@@ -5105,7 +5105,7 @@ author = {Gronau, Reuben},
 journal = {Journal of Political Economy},
 number = {2},
 pages = {1119--1143},
-title = {{{\{}W{\}}age {\{}C{\}}omparisons - {\{}A{\}} {\{}S{\}}electivity {\{}B{\}}ias}},
+title = {{Wage Comparisons - A Selectivity Bias}},
 volume = {82},
 year = {1974}
 }
@@ -5114,46 +5114,46 @@ author = {Grossman, Michael},
 journal = {Journal of Political Economy},
 number = {2},
 pages = {223--255},
-title = {{{\{}O{\}}n the {\{}C{\}}oncept of {\{}H{\}}ealth {\{}C{\}}apital and the {\{}D{\}}emand for {\{}H{\}}ealth}},
+title = {{On the Concept of Health Capital and the Demand for Health}},
 volume = {80},
 year = {1972}
 }
 @incollection{Grossman.2006,
 address = {Amsterdam, NL},
 author = {Grossman, Michael},
-booktitle = {{\{}H{\}}andbook of the {\{}E{\}}conomics of {\{}E{\}}ducation},
+booktitle = {Handbook of the Economics of Education},
 editor = {Hanushek, Eric A and Welch, John F},
 pages = {577--633},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}E{\}}ducation and {\{}N{\}}onmarket {\{}O{\}}utcomes}},
+title = {{Education and Nonmarket Outcomes}},
 year = {2006}
 }
 @article{Grossman.1973,
 author = {Grossman, Michael},
 journal = {NBER Working Paper},
-title = {{{\{}T{\}}he {\{}C{\}}orrelation {\{}B{\}}etween {\{}H{\}}ealth and {\{}S{\}}chooling}},
+title = {{The Correlation Between Health and Schooling}},
 volume = {22},
 year = {1973}
 }
 @incollection{Grossman.2000b,
 address = {Amsterdam, NL},
 author = {Grossman, Michael},
-booktitle = {{\{}H{\}}andbook of {\{}H{\}}ealth {\{}E{\}}conomics},
+booktitle = {Handbook of Health Economics},
 editor = {Culyer, Anthony J and Newhouse, Joseph P},
 pages = {347--408},
 publisher = {Elsevier Science},
-title = {{{\{}T{\}}he {\{}H{\}}uman {\{}C{\}}apital {\{}M{\}}odel}},
+title = {{The Human Capital Model}},
 volume = {1},
 year = {2000}
 }
 @incollection{Grossman.1997,
-address = {Ann{\$}{\~{}}{\$}Arbor, MI},
+address = {Ann Arbor, MI},
 author = {Grossman, Michael and Kaestner, Robert},
-booktitle = {{\{}T{\}}he {\{}S{\}}ocial {\{}B{\}}enefits of {\{}E{\}}ducation},
+booktitle = {The Social Benefits of Education},
 editor = {Behrman, Jere R and Nevzer, Stacey},
 pages = {69--123},
 publisher = {University of Michigan Press},
-title = {{{\{}E{\}}ffects of {\{}E{\}}ducation on {\{}H{\}}ealth}},
+title = {{Effects of Education on Health}},
 year = {1997}
 }
 @article{Grossman.1993,
@@ -5161,7 +5161,7 @@ author = {Grossman, Michael and Sindelar, Jody L and Mullahy, John and Anderson,
 journal = {Journal of Economic Perspectives},
 number = {4},
 pages = {211--222},
-title = {{{\{}P{\}}olicy {\{}W{\}}atch: {\{}A{\}}lcohol and {\{}C{\}}igarrete {\{}T{\}}axes}},
+title = {{Policy Watch: Alcohol and Cigarrete Taxes}},
 volume = {7},
 year = {1993}
 }
@@ -5169,7 +5169,7 @@ year = {1993}
 address = {New York, NY},
 author = {Gut, Allan},
 publisher = {Springer},
-title = {{{\{}P{\}}robability:{\$}{\~{}}{\$}{\{}A{\}} {\{}G{\}}raduate {\{}C{\}}ourse}},
+title = {{Probability: A Graduate Course}},
 year = {2005}
 }
 @article{Haavelmo.1943a,
@@ -5201,7 +5201,7 @@ author = {Hahn, Jinyuong and Todd, Petra E and van der Klaauw, Wilbert},
 journal = {Econometrica},
 number = {1},
 pages = {201--209},
-title = {{{\{}I{\}}dentification and {\{}E{\}}stimation of {\{}T{\}}reatment {\{}E{\}}ffects with a {\{}R{\}}egression-{\{}D{\}}iscontinuity {\{}D{\}}esign}},
+title = {{Identification and Estimation of Treatment Effects with a Regression-Discontinuity Design}},
 volume = {69},
 year = {2001}
 }
@@ -5222,7 +5222,7 @@ author = {Haider, Steven J and Solon, Gary},
 journal = {American Economic Review},
 number = {4},
 pages = {1308--1320},
-title = {{{\{}L{\}}ife-{\{}C{\}}ycle {\{}V{\}}ariation in the {\{}A{\}}ssociation {\{}B{\}}etween {\{}C{\}}urrent and {\{}L{\}}ifetime {\{}E{\}}arnings}},
+title = {{Life-Cycle Variation in the Association Between Current and Lifetime Earnings}},
 volume = {96},
 year = {2006}
 }
@@ -5266,7 +5266,7 @@ year = {2001}
 address = {Amsterdam, NL},
 editor = {Hammermesh, Daniel S and Pfann, Gerard A},
 publisher = {Elsevier Science},
-title = {{{\{}T{\}}he {\{}E{\}}conomics of {\{}T{\}}ime {\{}U{\}}se}},
+title = {{The Economics of Time Use}},
 year = {2005}
 }
 @book{Hamming.1987,
@@ -5294,11 +5294,11 @@ year = {1988}
 @incollection{Hampson.2008,
 address = {New York, NY},
 author = {Hampson, Sarah E and Friedman, H S},
-booktitle = {{\{}H{\}}andbook of {\{}P{\}}ersonality:{\$}{\~{}}{\$}{\{}T{\}}heory and {\{}R{\}}eserach},
+booktitle = {Handbook of Personality: Theory and Reserach},
 editor = {John, Oliver P and Robins, Robert and Pervin, Lawrence A},
 pages = {770--794},
 publisher = {Guilford},
-title = {{{\{}P{\}}ersonality and {\{}H{\}}ealth: {\{}A{\}} {\{}L{\}}ifespan {\{}P{\}}erspective}},
+title = {{Personality and Health: A Lifespan Perspective}},
 year = {2008}
 }
 @article{Hampson.2006,
@@ -5306,7 +5306,7 @@ author = {Hampson, Sarah E and Goldberg, Lewis R and Vogt, Thomas M and Dubanosk
 journal = {Health Psychology},
 number = {1},
 pages = {57--64},
-title = {{{\{}F{\}}orty {\{}Y{\}}ears {\{}O{\}}n: {\{}T{\}}eachers' {\{}A{\}}ssessments of {\{}C{\}}hildren's {\{}P{\}}ersonality {\{}T{\}}raits {\{}P{\}}redict {\{}S{\}}elf-{\{}R{\}}eported {\{}H{\}}ealth {\{}B{\}}ehaviors and {\{}O{\}}utcomes at {\{}M{\}}idlife}},
+title = {{Forty Years On: Teachers' Assessments of Children's Personality Traits Predict Self-Reported Health Behaviors and Outcomes at Midlife}},
 volume = {25},
 year = {2006}
 }
@@ -5315,7 +5315,7 @@ author = {Han, Song and Mulligan, Casey B},
 journal = {The Economic Journal},
 number = {470},
 pages = {207--243},
-title = {{{\{}H{\}}uman {\{}C{\}}apital, {\{}H{\}}eterogeneity and {\{}E{\}}stimated {\{}D{\}}egrees of {\{}I{\}}ntergenerational {\{}M{\}}obility}},
+title = {{Human Capital, Heterogeneity and Estimated Degrees of Intergenerational Mobility}},
 volume = {111},
 year = {2001}
 }
@@ -5329,7 +5329,7 @@ isbn = {0412286602},
 issn = {00359254},
 number = {1},
 pages = {237},
-publisher = {Chapman {\&} Hall},
+publisher = {Chapman \& Hall},
 title = {{Statistical Reasoning with Imprecise Probabilities}},
 volume = {42},
 year = {1993}
@@ -5339,7 +5339,7 @@ author = {Hansen, Karsten and Heckman, James J and Mullen, Kathleen},
 journal = {Journal of Econometrics},
 number = {1-2},
 pages = {39--89},
-title = {{{\{}T{\}}he {\{}E{\}}ffect of {\{}S{\}}chooling and {\{}A{\}}bility on {\{}A{\}}chievement {\{}T{\}}est {\{}S{\}}cores}},
+title = {{The Effect of Schooling and Ability on Achievement Test Scores}},
 volume = {121},
 year = {2004}
 }
@@ -5354,14 +5354,14 @@ year = {2015}
 address = {Cambridge, UK},
 editor = {Hansen, Lars P and Dewatripont, Mathias and Turnovsky, Stephen J},
 publisher = {Cambridge University Press},
-title = {{{\{}A{\}}dvances in {\{}E{\}}conometrics:{\$}{\~{}}{\$}{\{}T{\}}heory and {\{}A{\}}pplications, {\{}E{\}}igth {\{}W{\}}orld {\{}C{\}}ongress}},
+title = {{Advances in Econometrics: Theory and Applications, Eigth World Congress}},
 year = {2003}
 }
 @book{Hansen.2003,
 address = {Cambridge, UK},
 editor = {Hansen, Lars P and Dewatripont, Mathias and Turnovsky, Stephen J},
 publisher = {Cambridge University Press},
-title = {{{\{}A{\}}dvances in {\{}E{\}}conometrics:{\$}{\~{}}{\$}{\{}T{\}}heory and {\{}A{\}}pplications, {\{}E{\}}igth {\{}W{\}}orld {\{}C{\}}ongress}},
+title = {{Advances in Econometrics: Theory and Applications, Eigth World Congress}},
 year = {2003}
 }
 @book{Hansen.2014,
@@ -5375,7 +5375,7 @@ author = {Hansen, Lars P and Sargent, Thomas J},
 journal = {Journal of Economic Dynamics and Control},
 number = {2},
 pages = {7--46},
-title = {{{\{}F{\}}ormulating and {\{}E{\}}stimating {\{}D{\}}ynamic {\{}L{\}}inear {\{}R{\}}ational {\{}E{\}}xpectations {\{}M{\}}odels}},
+title = {{Formulating and Estimating Dynamic Linear Rational Expectations Models}},
 volume = {2},
 year = {1980}
 }
@@ -5383,7 +5383,7 @@ year = {1980}
 address = {Minneapolis, MN},
 author = {Hansen, Lars P and Singelton, Kenneth},
 publisher = {University of Minnesota Press},
-title = {{{\{}R{\}}ational {\{}E{\}}xpectations and {\{}E{\}}conometric {\{}P{\}}ractice}},
+title = {{Rational Expectations and Econometric Practice}},
 year = {1981}
 }
 @article{Hansen.2003b,
@@ -5452,7 +5452,7 @@ author = {Hanushek, Eric A},
 journal = {Journal of Economic Literature},
 number = {3},
 pages = {1141--1177},
-title = {{{\{}T{\}}he {\{}E{\}}conomics of {\{}S{\}}chooling:{\$}{\~{}}{\$}{\{}P{\}}roduction and {\{}E{\}}fficiency in {\{}P{\}}ublic {\{}S{\}}chools}},
+title = {{The Economics of Schooling: Production and Efficiency in Public Schools}},
 volume = {24},
 year = {1986}
 }
@@ -5460,21 +5460,21 @@ year = {1986}
 address = {Washington, D.C.},
 editor = {Hanushek, Eric A},
 publisher = {Brookings Institution Press},
-title = {{{\{}M{\}}aking {\{}S{\}}chools {\{}W{\}}ork: {\{}I{\}}mproving {\{}P{\}}erformance and {\{}C{\}}ontrolling {\{}C{\}}osts}},
+title = {{Making Schools Work: Improving Performance and Controlling Costs}},
 year = {1994}
 }
 @book{Hanushek.2006,
 address = {Amsterdam, NL},
 editor = {Hanushek, Eric A and Welch, John F},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}H{\}}andbook of the {\{}E{\}}conomics of {\{}E{\}}ducation}},
+title = {{Handbook of the Economics of Education}},
 year = {2006}
 }
 @book{Hanushek.2006a,
 address = {Amsterdam, NL},
 editor = {Hanushek, Eric A and Welch, John F},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}H{\}}andbook of the {\{}E{\}}conomics of {\{}E{\}}ducation}},
+title = {{Handbook of the Economics of Education}},
 year = {2006}
 }
 @book{Harberger.2002,
@@ -5488,7 +5488,7 @@ year = {2002}
 author = {Harris, Judith R},
 journal = {Psychological Review},
 pages = {458--489},
-title = {{{\{}W{\}}here is the {\{}C{\}}hild {\{}E{\}}nvironment?{\$}{\~{}}{\$}{\{}A{\}}{\$}{\~{}}{\$}{\{}G{\}}roup {\{}S{\}}ocialisation {\{}T{\}}heory of {\{}D{\}}evelopment}},
+title = {{Where is the Child Environment? A Group Socialisation Theory of Development}},
 volume = {102},
 year = {1995}
 }
@@ -5496,7 +5496,7 @@ year = {1995}
 address = {New York, NY},
 author = {Harris, Judith R},
 publisher = {The Free Press},
-title = {{{\{}T{\}}he {\{}N{\}}urture {\{}A{\}}ssumption}},
+title = {{The Nurture Assumption}},
 year = {1998}
 }
 @article{Harris.1982,
@@ -5504,7 +5504,7 @@ author = {Harris, Milton and Holmstrom, Bengt},
 journal = {The Review of Economics and Statistics},
 number = {3},
 pages = {315--333},
-title = {{{\{}A{\}} {\{}T{\}}heory of {\{}W{\}}age {\{}D{\}}ynamics}},
+title = {{A Theory of Wage Dynamics}},
 volume = {49},
 year = {1982}
 }
@@ -5513,7 +5513,7 @@ author = {Hart, Betty and Risley, Todd R},
 journal = {Developmental Psychology},
 number = {6},
 pages = {1096--1105},
-title = {{{\{}A{\}}merican {\{}P{\}}arenting of {\{}L{\}}anguage-{\{}L{\}}earning {\{}C{\}}hildren:{\$}{\~{}}{\$}{\{}P{\}}ersisting {\{}D{\}}ifferences in {\{}F{\}}amily-{\{}C{\}}hild {\{}I{\}}nteractions {\{}O{\}}bserved in {\{}N{\}}atural {\{}H{\}}ome {\{}E{\}}nvironments}},
+title = {{American Parenting of Language-Learning Children: Persisting Differences in Family-Child Interactions Observed in Natural Home Environments}},
 volume = {28},
 year = {1992}
 }
@@ -5521,7 +5521,7 @@ year = {1992}
 address = {Baltimore, MD},
 author = {Hart, Betty and Risley, Todd R},
 publisher = {P. H. Brookes},
-title = {{{\{}M{\}}eaningful {\{}D{\}}ifferences in the {\{}E{\}}veryday {\{}E{\}}xperience of {\{}Y{\}}oung {\{}A{\}}merican {\{}C{\}}hildren}},
+title = {{Meaningful Differences in the Everyday Experience of Young American Children}},
 year = {1995}
 }
 @article{Hartog.1998,
@@ -5529,7 +5529,7 @@ author = {Hartog, Joop and {Oosterbeekm Hessel}},
 journal = {Economics of Education Review},
 number = {3},
 pages = {245--256},
-title = {{{\{}H{\}}ealth, {\{}W{\}}ealth, and {\{}H{\}}appiness;{\$}{\~{}}{\$}{\{}W{\}}hy {\{}P{\}}ursue a {\{}H{\}}igher {\{}E{\}}ducation}},
+title = {{Health, Wealth, and Happiness; Why Pursue a Higher Education}},
 volume = {17},
 year = {1998}
 }
@@ -5537,14 +5537,14 @@ year = {1998}
 address = {Cambridge, MA},
 author = {Harvey, Andrew C},
 publisher = {Cambridge University Press},
-title = {{{\{}F{\}}orecasting, {\{}S{\}}tructural {\{}T{\}}ime {\{}S{\}}eries {\{}M{\}}odels and the {\{}K{\}}alman {\{}F{\}}ilter}},
+title = {{Forecasting, Structural Time Series Models and the Kalman Filter}},
 year = {1989}
 }
 @book{Harvey.2004,
 address = {Cambridge, UK},
 editor = {Harvey, Andrew C and Koopman, Siem J and Shephard, Neil},
 publisher = {Cambridge University Press},
-title = {{{\{}S{\}}tate {\{}S{\}}pace and {\{}U{\}}nobserved {\{}C{\}}omponent {\{}M{\}}odels:{\$}{\~{}}{\$}{\{}T{\}}heory and {\{}A{\}}pplication}},
+title = {{State Space and Unobserved Component Models: Theory and Application}},
 year = {2004}
 }
 @book{Hashimoto.2013,
@@ -5558,7 +5558,7 @@ year = {2013}
 address = {Washington, D.C},
 author = {Haskins, Ron and Sawhill, Isabel},
 publisher = {The Brookings Institution},
-title = {{{\{}C{\}}reating an {\{}O{\}}pportunity {\{}S{\}}ociety}},
+title = {{Creating an Opportunity Society}},
 year = {2009}
 }
 @article{Hatfield.2012,
@@ -5589,7 +5589,7 @@ year = {1978}
 address = {New York, NY},
 author = {Haveman, Robert and Wolfe, Barbara},
 publisher = {Russel Sage Foundation},
-title = {{{\{}S{\}}ucceding {\{}G{\}}enerations: {\{}O{\}}n the {\{}E{\}}ffects of {\{}I{\}}nvestment in {\{}C{\}}hildren}},
+title = {{Succeding Generations: On the Effects of Investment in Children}},
 year = {1994}
 }
 @article{Haveman.1993,
@@ -5597,7 +5597,7 @@ author = {Haveman, Robert and Wolfe, Barbara},
 journal = {The Journal of Economic Perspectives},
 number = {4},
 pages = {153--174},
-title = {{{\{}C{\}}hildren''s {\{}P{\}}rospects and {\{}C{\}}hildren's {\{}P{\}}olicy}},
+title = {{Children''s Prospects and Children's Policy}},
 volume = {7},
 year = {1993}
 }
@@ -5606,7 +5606,7 @@ author = {Haveman, Robert and Wolfe, Barbara},
 journal = {Journal of Economic Literature},
 number = {4},
 pages = {1829--1878},
-title = {{{\{}T{\}}he {\{}D{\}}eterminants of {\{}C{\}}hildren's {\{}A{\}}ttainments: {\{}A{\}} {\{}R{\}}eview of {\{}M{\}}ethods and {\{}F{\}}indings}},
+title = {{The Determinants of Children's Attainments: A Review of Methods and Findings}},
 volume = {33},
 year = {1995}
 }
@@ -5615,7 +5615,7 @@ author = {Haveman, Robert and Wolfe, Barbara and Spaulding, James},
 journal = {Demography},
 number = {1},
 pages = {133--158},
-title = {{{\{}C{\}}hild {\{}E{\}}vents and {\{}C{\}}ircumstances {\{}A{\}}ffecting {\{}H{\}}igh {\{}S{\}}chool {\{}C{\}}ompletion}},
+title = {{Child Events and Circumstances Affecting High School Completion}},
 volume = {28},
 year = {1991}
 }
@@ -5665,7 +5665,7 @@ number = {8},
 pages = {4730--4734},
 pmid = {10200330},
 title = {{Local Instrumental Variables and Latent Variable Models for Identifying and Bounding Treatment Effects.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=16400{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=16400&tool=pmcentrez&rendertype=abstract},
 volume = {96},
 year = {1999}
 }
@@ -5739,7 +5739,7 @@ number = {3},
 pages = {289},
 pmid = {20119503},
 title = {{Schools, Skills, and Synapses.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=2812935{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=2812935&tool=pmcentrez&rendertype=abstract},
 volume = {46},
 year = {2008}
 }
@@ -5748,7 +5748,7 @@ author = {Heckman, James J},
 journal = {Econometrica},
 number = {4},
 pages = {679--694},
-title = {{{\{}S{\}}hadow {\{}P{\}}rices, {\{}M{\}}arket {\{}W{\}}ages, and {\{}L{\}}abor {\{}S{\}}upply}},
+title = {{Shadow Prices, Market Wages, and Labor Supply}},
 volume = {42},
 year = {1974}
 }
@@ -5766,7 +5766,7 @@ author = {Heckman, James J},
 journal = {Research in Economics},
 number = {1},
 pages = {3--56},
-title = {{{\{}P{\}}olicies to {\{}F{\}}oster {\{}H{\}}uman {\{}C{\}}apital}},
+title = {{Policies to Foster Human Capital}},
 volume = {54},
 year = {2000}
 }
@@ -5787,7 +5787,7 @@ author = {Heckman, James J},
 journal = {Journal of Political Economy},
 number = {4},
 pages = {673--748},
-title = {{{\{}M{\}}icro {\{}D{\}}ata, {\{}H{\}}eterogeneity, and the {\{}E{\}}valuation of {\{}P{\}}ublic {\{}P{\}}olicy: {\{}N{\}}obel {\{}L{\}}ecture}},
+title = {{Micro Data, Heterogeneity, and the Evaluation of Public Policy: Nobel Lecture}},
 volume = {109},
 year = {2001}
 }
@@ -5795,7 +5795,7 @@ year = {2001}
 author = {Heckman, James J},
 journal = {NBER Technical Working Paper},
 number = {185},
-title = {{{\{}I{\}}nstrumental {\{}V{\}}ariables: {\{}A{\}} {\{}C{\}}autionary {\{}T{\}}ale}},
+title = {{Instrumental Variables: A Cautionary Tale}},
 year = {1995}
 }
 @article{Heckman.1997b,
@@ -5803,19 +5803,19 @@ author = {Heckman, James J},
 journal = {The Journal of Human Resources},
 number = {3},
 pages = {441--462},
-title = {{{\{}I{\}}nstrumental {\{}V{\}}ariables: {\{}A{\}} {\{}S{\}}tudy of {\{}I{\}}mplicit {\{}B{\}}ehavioral {\{}A{\}}ssumptions {\{}U{\}}sed in {\{}M{\}}aking {\{}P{\}}rogram {\{}E{\}}valuations}},
+title = {{Instrumental Variables: A Study of Implicit Behavioral Assumptions Used in Making Program Evaluations}},
 volume = {32},
 year = {1997}
 }
 @article{Heckman2011,
 author = {Heckman, James J},
 journal = {Working Paper},
-title = {{{\{}T{\}}he {\{}D{\}}ecline of the {\{}A{\}}merican {\{}F{\}}amily in {\{}B{\}}lack and {\{}W{\}}hite: {\{}A{\}} {\{}P{\}}ost-{\{}R{\}}acial {\{}A{\}}rgument for {\{}I{\}}mproving {\{}S{\}}kills to {\{}P{\}}romote {\{}E{\}}quality}},
+title = {{The Decline of the American Family in Black and White: A Post-Racial Argument for Improving Skills to Promote Equality}},
 year = {2011}
 }
 @article{Heckman.2005,
 author = {Heckman, James J},
-title = {{{\{}T{\}}{\{}H{\}}{\{}E{\}} {\{}G{\}}{\{}E{\}}{\{}D{\}}, {\{}C{\}}enter for {\{}S{\}}ocial {\{}P{\}}rogram {\{}E{\}}valuation}},
+title = {{THE GED, Center for Social Program Evaluation}},
 year = {2005}
 }
 @article{Heckman.1984,
@@ -5832,17 +5832,17 @@ author = {Heckman, James J},
 journal = {Proceedings of the National Academy of Science},
 number = {33},
 pages = {13250--13255},
-title = {{{\{}T{\}}he {\{}E{\}}conomics, {\{}T{\}}echnology and {\{}N{\}}euroscience of {\{}H{\}}uman {\{}C{\}}apability {\{}F{\}}ormation}},
+title = {{The Economics, Technology and Neuroscience of Human Capability Formation}},
 volume = {104},
 year = {2007}
 }
 @incollection{Heckman.1980,
 address = {Beverly Hills, CA},
 author = {Heckman, James J},
-booktitle = {{\{}E{\}}valuation {\{}S{\}}tudies {\{}R{\}}eview {\{}A{\}}nnual},
+booktitle = {Evaluation Studies Review Annual},
 editor = {Stromsdorfer, S and Farkas, George},
 publisher = {Sage Publications},
-title = {{{\{}A{\}}ddendum to {\{}S{\}}ample {\{}S{\}}election {\{}B{\}}ias as a {\{}S{\}}pecification{\$}{\~{}}{\$}{\{}E{\}}rror}},
+title = {{Addendum to Sample Selection Bias as a Specification Error}},
 volume = {5},
 year = {1980}
 }
@@ -5850,21 +5850,21 @@ year = {1980}
 author = {Heckman, James J},
 journal = {Economic Inquiry},
 pages = {289--324},
-title = {{{\{}S{\}}chools, {\{}S{\}}kills, and {\{}S{\}}ynapses}},
+title = {{Schools, Skills, and Synapses}},
 volume = {46},
 year = {2008}
 }
 @article{Heckman.2005b,
 author = {Heckman, James J},
 journal = {NBER Working Paper},
-title = {{{\{}L{\}}essons from the {\{}T{\}}echnology of {\{}S{\}}kil {\{}F{\}}ormation}},
+title = {{Lessons from the Technology of Skil Formation}},
 volume = {11142},
 year = {2005}
 }
 @article{Heckman.2007,
 author = {Heckman, James J},
 journal = {NBER Working Paper},
-title = {{{\{}T{\}}he {\{}E{\}}conomics, {\{}T{\}}echnology and {\{}N{\}}euroscience of {\{}H{\}}uman {\{}C{\}}apability {\{}F{\}}ormation}},
+title = {{The Economics, Technology and Neuroscience of Human Capability Formation}},
 volume = {13195},
 year = {2007}
 }
@@ -5873,7 +5873,7 @@ author = {Heckman, James J},
 journal = {Journal of Political Economy},
 number = {5},
 pages = {1091--1120},
-title = {{{\{}L{\}}essons from the {\{}B{\}}ell {\{}C{\}}urve}},
+title = {{Lessons from the Bell Curve}},
 volume = {103},
 year = {1995}
 }
@@ -5882,21 +5882,21 @@ author = {Heckman, James J},
 journal = {American Economic Review},
 number = {2},
 pages = {313--318},
-title = {{{\{}V{\}}arieties of {\{}S{\}}election {\{}B{\}}ias}},
+title = {{Varieties of Selection Bias}},
 volume = {80},
 year = {1990}
 }
 @article{Heckman.2008d,
 author = {Heckman, James J},
 journal = {Working Paper},
-title = {{{\{}T{\}}he{\$}{\~{}}{\$}{\{}E{\}}conomics and {\{}P{\}}sychology of {\{}I{\}}nequality and {\{}H{\}}uman {\{}D{\}}evelopment}},
+title = {{The Economics and Psychology of Inequality and Human Development}},
 volume = {The Univer},
 year = {2008}
 }
 @article{Heckman.2010b,
 author = {Heckman, James J},
 journal = {Annales de Economique et de Statistique},
-title = {{{\{}T{\}}he {\{}P{\}}rinciples {\{}U{\}}nderlying {\{}E{\}}valuation {\{}E{\}}stimators with an {\{}A{\}}pplication to {\{}M{\}}atching}},
+title = {{The Principles Underlying Evaluation Estimators with an Application to Matching}},
 volume = {91-91},
 year = {2010}
 }
@@ -5912,7 +5912,7 @@ number = {33},
 pages = {13250--13255},
 pmid = {17686985},
 title = {{The economics, technology, and neuroscience of human capability formation.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1948899{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1948899&tool=pmcentrez&rendertype=abstract},
 volume = {104},
 year = {2007}
 }
@@ -5921,14 +5921,14 @@ author = {Heckman, James J},
 journal = {Econometrica},
 number = {1},
 pages = {153--161},
-title = {{{\{}S{\}}ample {\{}S{\}}election {\{}B{\}}ias as a {\{}S{\}}pecification {\{}E{\}}rror}},
+title = {{Sample Selection Bias as a Specification Error}},
 volume = {74},
 year = {1979}
 }
 @article{Heckman.2007a,
 author = {Heckman, James J},
 journal = {IZA Discussion Paper},
-title = {{{\{}T{\}}he {\{}E{\}}conomics, {\{}T{\}}echnology and {\{}N{\}}euroscience of {\{}H{\}}uman {\{}C{\}}apability {\{}F{\}}ormation}},
+title = {{The Economics, Technology and Neuroscience of Human Capability Formation}},
 volume = {No. 2875},
 year = {2007}
 }
@@ -5944,7 +5944,7 @@ number = {33},
 pages = {13250--13255},
 pmid = {17686985},
 title = {{The economics, technology, and neuroscience of human capability formation.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1948899{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1948899&tool=pmcentrez&rendertype=abstract},
 volume = {104},
 year = {2007}
 }
@@ -5961,11 +5961,11 @@ year = {2008}
 @incollection{Heckman.1992,
 address = {Cambridge, MA},
 author = {Heckman, James J},
-booktitle = {{\{}E{\}}valuating {\{}W{\}}elfare and {\{}T{\}}raining {\{}P{\}}rograms},
+booktitle = {Evaluating Welfare and Training Programs},
 editor = {Manski, C and Garfinkel, Irwin},
 pages = {201--230},
 publisher = {Harvard University Press},
-title = {{{\{}R{\}}andomization and {\{}S{\}}ocial {\{}P{\}}olicy {\{}E{\}}valuation}},
+title = {{Randomization and Social Policy Evaluation}},
 year = {1992}
 }
 @article{Heckman.2010d,
@@ -5973,18 +5973,18 @@ author = {Heckman, James J},
 journal = {Journal of Economic Literature},
 number = {2},
 pages = {356--398},
-title = {{{\{}B{\}}uilding {\{}B{\}}ridges {\{}B{\}}etween {\{}S{\}}tructural and {\{}P{\}}rogram {\{}E{\}}valuation {\{}A{\}}pproaches to {\{}E{\}}valuating {\{}P{\}}olicies}},
+title = {{Building Bridges Between Structural and Program Evaluation Approaches to Evaluating Policies}},
 volume = {48},
 year = {2010}
 }
 @incollection{Heckman.1981,
 address = {Chicago, IL},
 author = {Heckman, James J},
-booktitle = {{\{}S{\}}tructural {\{}A{\}}nalysis of {\{}D{\}}iscrete {\{}D{\}}ata with {\{}E{\}}conometric {\{}A{\}}pplication},
+booktitle = {Structural Analysis of Discrete Data with Econometric Application},
 editor = {Manski, C and McFadden, Daniel},
 pages = {114--178},
-publisher = {MIT{\$}{\~{}}{\$}Press},
-title = {{{\{}S{\}}tatistical {\{}M{\}}odels for {\{}D{\}}iscrete {\{}P{\}}anel {\{}D{\}}ata}},
+publisher = {MIT Press},
+title = {{Statistical Models for Discrete Panel Data}},
 year = {1981}
 }
 @article{Heckman2007,
@@ -5999,7 +5999,7 @@ number = {33},
 pages = {13250--13255},
 pmid = {17686985},
 title = {{The economics, technology, and neuroscience of human capability formation.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1948899{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1948899&tool=pmcentrez&rendertype=abstract},
 volume = {104},
 year = {2007}
 }
@@ -6008,7 +6008,7 @@ author = {Heckman, James J and Honore, Bo E},
 journal = {Econometrica},
 number = {5},
 pages = {1121--1149},
-title = {{{\{}T{\}}he {\{}E{\}}mpirical {\{}C{\}}ontent of the {\{}R{\}}oy {\{}M{\}}odel}},
+title = {{The Empirical Content of the Roy Model}},
 volume = {58},
 year = {1990}
 }
@@ -6017,21 +6017,21 @@ author = {Heckman, James J and Hotz, Joseph V},
 journal = {Journal of the American Statistical Association},
 number = {408},
 pages = {862--874},
-title = {{{\{}C{\}}hoosing {\{}A{\}}mong {\{}A{\}}lternative {\{}N{\}}onexperimental {\{}M{\}}ethods {\{}F{\}}or {\{}E{\}}stimating {\{}T{\}}he {\{}I{\}}mpact {\{}O{\}}f {\{}S{\}}ocial {\{}P{\}}rograms: {\{}T{\}}he {\{}C{\}}ase {\{}O{\}}f {\{}M{\}}anpower {\{}T{\}}raining}},
+title = {{Choosing Among Alternative Nonexperimental Methods For Estimating The Impact Of Social Programs: The Case Of Manpower Training}},
 volume = {84},
 year = {1989}
 }
 @article{Heckman.1999h,
 author = {Heckman, James J and Hsee, Jingjing and Rubinstein, Yona},
 journal = {Working Paper},
-title = {{{\{}T{\}}he {\{}G{\}}{\{}E{\}}{\{}D{\}}{\$}{\~{}}{\$}is a {\{}M{\}}ixed {\{}S{\}}ignal}},
+title = {{The GED is a Mixed Signal}},
 volume = {The Univer},
 year = {1999}
 }
 @article{Heckman.2001b,
 author = {Heckman, James J and Hsse, Jingjing},
 journal = {Working Paper},
-title = {{{\{}T{\}}he {\{}G{\}}{\{}E{\}}{\{}D{\}} is a ''{\{}M{\}}ixed {\{}S{\}}ignal'': {\{}T{\}}he {\{}E{\}}ffect of {\{}C{\}}ognitive and {\{}N{\}}oncognitive {\{}S{\}}kills on {\{}H{\}}uman {\{}C{\}}apital and {\{}L{\}}abor {\{}M{\}}arket {\{}O{\}}utcomes}},
+title = {{The GED is a ''Mixed Signal'': The Effect of Cognitive and Noncognitive Skills on Human Capital and Labor Market Outcomes}},
 volume = {The Univer},
 year = {2001}
 }
@@ -6058,14 +6058,14 @@ author = {Heckman, James J and Ichimura, Hidehiko and Smith, Jeffrey and Todd, P
 journal = {Econometrica},
 number = {5},
 pages = {1017--1098},
-title = {{{\{}C{\}}haracterizing {\{}S{\}}election {\{}B{\}}ias {\{}U{\}}sing {\{}E{\}}xperimental {\{}D{\}}ata}},
+title = {{Characterizing Selection Bias Using Experimental Data}},
 volume = {66},
 year = {1998}
 }
 @article{Heckman.2010,
 author = {Heckman, James J and Jacobs, Bas},
 journal = {NBER Working Paper},
-title = {{{\{}P{\}}olicies to {\{}C{\}}reate and {\{}D{\}}estroy {\{}H{\}}uman {\{}C{\}}apital in {\{}E{\}}urope}},
+title = {{Policies to Create and Destroy Human Capital in Europe}},
 year = {2010}
 }
 @article{Heckman.2013,
@@ -6084,21 +6084,21 @@ year = {2013}
 @book{Heckman.2003,
 address = {Cambridge, MA},
 editor = {Heckman, James J and Krueger, Alan B},
-publisher = {MIT{\$}{\~{}}{\$}Press},
-title = {{{\{}I{\}}nequality in {\{}A{\}}merica: {\{}W{\}}hat {\{}R{\}}ole for {\{}H{\}}uman {\{}C{\}}apital {\{}P{\}}olicies?}},
+publisher = {MIT Press},
+title = {{Inequality in America: What Role for Human Capital Policies?}},
 year = {2003}
 }
 @book{Heckman.2002,
 address = {Cambridge, MA},
 editor = {Heckman, James J and Krueger, Alan B},
-publisher = {MIT{\$}{\~{}}{\$}Press},
-title = {{{\{}I{\}}nequality in {\{}A{\}}merica: {\{}W{\}}hat {\{}R{\}}ole for {\{}H{\}}uman {\{}C{\}}apital {\{}P{\}}olicies?}},
+publisher = {MIT Press},
+title = {{Inequality in America: What Role for Human Capital Policies?}},
 year = {2003}
 }
 @article{Heckman.2008c,
 author = {Heckman, James J and LaFontaine, Paul A},
 journal = {Working Paper},
-title = {{{\{}T{\}}esting the {\{}T{\}}est:{\$}{\~{}}{\$}{\{}W{\}}hat the {\{}G{\}}{\{}E{\}}{\{}D{\}} {\{}R{\}}eveals and {\{}C{\}}onceals}},
+title = {{Testing the Test: What the GED Reveals and Conceals}},
 volume = {The Univer},
 year = {2008}
 }
@@ -6107,32 +6107,32 @@ author = {Heckman, James J and LaFontaine, Paul A},
 journal = {Journal of Labor Economics},
 number = {3},
 pages = {661--700},
-title = {{{\{}B{\}}ias {\{}C{\}}orrected {\{}E{\}}stimates of {\{}G{\}}{\{}E{\}}{\{}D{\}}{\$}{\~{}}{\$}{\{}R{\}}eturns}},
+title = {{Bias Corrected Estimates of GED Returns}},
 volume = {24},
 year = {2006}
 }
 @incollection{Heckman.1999b,
 address = {Amsterdam, Netherlands},
 author = {Heckman, James J and LaLonde, Robert and Smith, Jeffrey},
-booktitle = {{\{}H{\}}andbook of {\{}L{\}}abor {\{}E{\}}conomics},
+booktitle = {Handbook of Labor Economics},
 editor = {Ashenfelter, Orley and Card, David},
 pages = {1865--2073},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}T{\}}he {\{}E{\}}conomics and {\{}E{\}}conometrics of {\{}A{\}}ctive {\{}L{\}}abor {\{}M{\}}arket {\{}P{\}}rograms}},
+title = {{The Economics and Econometrics of Active Labor Market Programs}},
 volume = {3A},
 year = {1999}
 }
 @article{Heckman.2004,
 author = {Heckman, James J and Larenas, Maria and los Santos, Babur},
 journal = {Working Paper},
-title = {{{\{}E{\}}xplaining the {\{}G{\}}ap in {\{}A{\}}chievement {\{}T{\}}est {\{}S{\}}cores for {\{}B{\}}lacks, {\{}H{\}}ispanics and {\{}W{\}}hites}},
+title = {{Explaining the Gap in Achievement Test Scores for Blacks, Hispanics and Whites}},
 volume = {The Univer},
 year = {2004}
 }
 @article{Heckman.2004b,
 author = {Heckman, James J and Larenas, Mario I and Urzua, Sergio},
 journal = {Working Paper},
-title = {{{\{}A{\}}ccounting for the {\{}E{\}}ffect of {\{}S{\}}chooling and {\{}A{\}}bilities in the {\{}A{\}}nalysis of {\{}R{\}}acial and {\{}E{\}}thnic {\{}D{\}}isparities in {\{}A{\}}chievement {\{}T{\}}est {\{}S{\}}cores}},
+title = {{Accounting for the Effect of Schooling and Abilities in the Analysis of Racial and Ethnic Disparities in Achievement Test Scores}},
 volume = {The Univer},
 year = {2004}
 }
@@ -6140,14 +6140,14 @@ year = {2004}
 address = {Amsterdam, NL},
 editor = {Heckman, James J and Leamer, Edward E},
 publisher = {Elsevier Science},
-title = {{{\{}H{\}}andbook of {\{}E{\}}conometrics}},
+title = {{Handbook of Econometrics}},
 year = {2007}
 }
 @book{Heckman.2001c,
 address = {Amsterdam, NL},
 editor = {Heckman, James J and Leamer, Edward E},
 publisher = {Elsevier Science},
-title = {{{\{}H{\}}andbook of {\{}E{\}}conometrics}},
+title = {{Handbook of Econometrics}},
 year = {2001}
 }
 @incollection{Heckman.2006a,
@@ -6165,7 +6165,7 @@ author = {Heckman, James J and Lochner, Lance and Taber, Christoph},
 journal = {Review of Economic Dynamics},
 number = {1},
 pages = {1--58},
-title = {{{\{}E{\}}xplaining {\{}R{\}}ising {\{}W{\}}age {\{}I{\}}nequality: {\{}E{\}}xplorations with a {\{}D{\}}ynamic {\{}G{\}}eneral {\{}E{\}}quilibrium {\{}M{\}}odel of {\{}L{\}}abor {\{}E{\}}arnings with {\{}H{\}}eterogeneous {\{}A{\}}gents}},
+title = {{Explaining Rising Wage Inequality: Explorations with a Dynamic General Equilibrium Model of Labor Earnings with Heterogeneous Agents}},
 volume = {1},
 year = {1998}
 }
@@ -6190,21 +6190,21 @@ author = {Heckman, James J and Masterov, Dimitriy V},
 journal = {Review of Agricultural Economics},
 number = {3},
 pages = {446--493},
-title = {{{\{}T{\}}he {\{}P{\}}roductivity {\{}A{\}}rgument for {\{}I{\}}nvesting in {\{}Y{\}}oung {\{}C{\}}hildren}},
+title = {{The Productivity Argument for Investing in Young Children}},
 volume = {29},
 year = {2007}
 }
 @article{Heckman.2009e,
 author = {Heckman, James J and Moon, Soeng Hyoek and Pinto, Rodrigo R and Savelyev, Peter},
 journal = {Working Paper},
-title = {{{\{}A{\}} {\{}R{\}}eanalysis of the {\{}H{\}}igh/{\{}S{\}}cope {\{}P{\}}erry {\{}P{\}}reschool {\{}P{\}}rogram}},
+title = {{A Reanalysis of the High/Scope Perry Preschool Program}},
 volume = {The Univer},
 year = {2008}
 }
 @article{Heckman.2009b,
 author = {Heckman, James J and Moon, Soeng Hyoek and Pinto, Rodrigo R and Yavitz, Adam},
 journal = {Journal of Public Economics},
-title = {{{\{}T{\}}he {\{}R{\}}ate of {\{}R{\}}eturn to the {\{}P{\}}erry {\{}P{\}}reschool {\{}P{\}}rogram}},
+title = {{The Rate of Return to the Perry Preschool Program}},
 volume = {forthcomin},
 year = {2008}
 }
@@ -6213,7 +6213,7 @@ author = {Heckman, James J and Navarro, Salvador},
 journal = {Journal of Econometrics},
 number = {2},
 pages = {341--396},
-title = {{{\{}D{\}}ynamic {\{}D{\}}iscrete {\{}C{\}}hoice and {\{}D{\}}ynamic {\{}T{\}}reatment {\{}E{\}}ffects}},
+title = {{Dynamic Discrete Choice and Dynamic Treatment Effects}},
 volume = {136},
 year = {2007}
 }
@@ -6222,7 +6222,7 @@ author = {Heckman, James J and Navarro, Salvador},
 journal = {Review of Economics and Statistics},
 number = {1},
 pages = {30--57},
-title = {{{\{}U{\}}sing {\{}M{\}}atching, {\{}I{\}}nstrumental {\{}V{\}}ariables, and {\{}C{\}}ontrol {\{}F{\}}unctions to {\{}E{\}}stimate {\{}E{\}}conomic {\{}C{\}}hoice {\{}M{\}}odels}},
+title = {{Using Matching, Instrumental Variables, and Control Functions to Estimate Economic Choice Models}},
 volume = {86},
 year = {2004}
 }
@@ -6238,7 +6238,7 @@ year = {2004}
 @article{Heckman.2008e,
 author = {Heckman, James J and Pinto, Rodrigo R and Malofeeva, Lena and Savelyev, Peter},
 journal = {Working Paper},
-title = {{{\{}T{\}}he {\{}R{\}}ole of {\{}C{\}}ognitive and {\{}N{\}}oncognitive {\{}S{\}}kills in {\{}E{\}}xplaining the {\{}E{\}}ffects of the {\{}H{\}}igh{\$}{\~{}}{\$}{\{}S{\}}cope {\{}P{\}}erry {\{}P{\}}reschool {\{}P{\}}rogram on {\{}P{\}}articipants}},
+title = {{The Role of Cognitive and Noncognitive Skills in Explaining the Effects of the High Scope Perry Preschool Program on Participants}},
 volume = {The Univer},
 year = {2008}
 }
@@ -6261,21 +6261,21 @@ year = {2013}
 @incollection{Heckman.1986,
 address = {New York, NY},
 author = {Heckman, James J and Robb, Richard},
-booktitle = {{\{}D{\}}rawing {\{}I{\}}nference from {\{}S{\}}elf-{\{}S{\}}elected {\{}S{\}}amples},
+booktitle = {Drawing Inference from Self-Selected Samples},
 editor = {Wainer, H},
 pages = {11--114},
 publisher = {Springer},
-title = {{{\{}A{\}}lternative {\{}M{\}}ethods for {\{}S{\}}olving the {\{}P{\}}roblem of {\{}S{\}}elf-{\{}S{\}}election {\{}B{\}}ias in{\$}{\~{}}{\$}{\{}E{\}}valuating the {\{}I{\}}mpact of {\{}T{\}}reatments on {\{}O{\}}utcomes}},
+title = {{Alternative Methods for Solving the Problem of Self-Selection Bias in Evaluating the Impact of Treatments on Outcomes}},
 year = {1986}
 }
 @incollection{Heckman.1985b,
 address = {Cambridge, MA},
 author = {Heckman, James J and Robb, Richard},
-booktitle = {{\{}L{\}}ongitudinal {\{}A{\}}nalysis of {\{}L{\}}abor {\{}M{\}}arket {\{}D{\}}ata},
+booktitle = {Longitudinal Analysis of Labor Market Data},
 editor = {Heckman, James J and Singer, Burton},
 pages = {156--245},
 publisher = {Cambridge University Press},
-title = {{{\{}A{\}}lteranative {\{}M{\}}ethods for {\{}E{\}}valuating the {\{}I{\}}mpact of {\{}I{\}}nterventions}},
+title = {{Alteranative Methods for Evaluating the Impact of Interventions}},
 year = {1985}
 }
 @article{Heckman.2001,
@@ -6283,7 +6283,7 @@ author = {Heckman, James J and Rubinstein, Yona},
 journal = {American Economic Review},
 number = {2},
 pages = {145--149},
-title = {{{\{}T{\}}he {\{}I{\}}mportance of {\{}N{\}}oncognitive {\{}S{\}}kills: {\{}L{\}}essons from the {\{}G{\}}{\{}E{\}}{\{}D{\}} {\{}T{\}}esting {\{}P{\}}rogram}},
+title = {{The Importance of Noncognitive Skills: Lessons from the GED Testing Program}},
 volume = {91},
 year = {2001}
 }
@@ -6323,17 +6323,17 @@ year = {1985}
 address = {Cambridge, MA},
 editor = {Heckman, James J and Singer, Burton},
 publisher = {Cambridge University Press},
-title = {{{\{}L{\}}ongitudinal {\{}A{\}}nalysis of {\{}L{\}}abor {\{}M{\}}arket {\{}D{\}}ata}},
+title = {{Longitudinal Analysis of Labor Market Data}},
 year = {1985}
 }
 @incollection{Heckman.1998,
 address = {Cambridge, United Kingdom},
 author = {Heckman, James J and Smith, Jeffrey},
-booktitle = {{\{}E{\}}conometrics and {\{}E{\}}conomic {\{}T{\}}heory in the 20th {\{}C{\}}entury},
+booktitle = {Econometrics and Economic Theory in the 20th Century},
 editor = {Strom, Steinar},
 pages = {241--318},
 publisher = {Cambridge University Press},
-title = {{{\{}E{\}}valuation the {\{}W{\}}elfare {\{}S{\}}tate: {\{}T{\}}he {\{}R{\}}agnar {\{}F{\}}risch {\{}C{\}}entennial {\{}S{\}}ymposium}},
+title = {{Evaluation the Welfare State: The Ragnar Frisch Centennial Symposium}},
 year = {1998}
 }
 @article{Heckman.1997,
@@ -6341,7 +6341,7 @@ author = {Heckman, James J and Smith, Jeffrey and Clements, Nancy},
 journal = {The Review of Economic Studies},
 number = {4},
 pages = {487--535},
-title = {{{\{}M{\}}aking the {\{}M{\}}ost {\{}O{\}}ut of {\{}P{\}}rogramme {\{}E{\}}valuations and {\{}S{\}}ocial {\{}E{\}}xperiments: {\{}A{\}}ccounting for {\{}H{\}}eterogeneity in {\{}P{\}}rogramme {\{}I{\}}mpacts}},
+title = {{Making the Most Out of Programme Evaluations and Social Experiments: Accounting for Heterogeneity in Programme Impacts}},
 volume = {64},
 year = {1997}
 }
@@ -6362,7 +6362,7 @@ author = {Heckman, James J and Stixrud, Jora and Urzua, Sergio},
 journal = {Journal of Labor Economics},
 number = {3},
 pages = {411--482},
-title = {{{\{}T{\}}he {\{}E{\}}ffects of {\{}C{\}}ognitive and {\{}N{\}}oncognitive {\{}A{\}}bilities on {\{}L{\}}abor {\{}M{\}}arket {\{}O{\}}utcomes and {\{}S{\}}ocial {\{}B{\}}ehavior}},
+title = {{The Effects of Cognitive and Noncognitive Abilities on Labor Market Outcomes and Social Behavior}},
 volume = {24},
 year = {2006}
 }
@@ -6377,14 +6377,14 @@ number = {1},
 pages = {27--37},
 pmid = {20440375},
 title = {{Comparing IV With Structural Models: What Simple IV Can and Cannot Identify.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=2861784{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=2861784&tool=pmcentrez&rendertype=abstract},
 volume = {156},
 year = {2010}
 }
 @article{Heckman.2006,
 author = {Heckman, James J and Urzua, Sergio and Vytlacil, Edward J},
 journal = {Working Paper},
-title = {{Online Documentation: {\{}U{\}}nderstanding {\{}I{\}}nstrumental {\{}V{\}}ariables in {\{}M{\}}odels with {\{}E{\}}ssential {\{}H{\}}eterogeneity}},
+title = {{Online Documentation: Understanding Instrumental Variables in Models with Essential Heterogeneity}},
 year = {2006}
 }
 @article{Heckman.2006d,
@@ -6392,18 +6392,18 @@ author = {Heckman, James J and Urzua, Sergio and Vytlacil, Edward J},
 journal = {The Review of Economics and Statistics},
 number = {3},
 pages = {389--432},
-title = {{{\{}U{\}}nderstanding {\{}I{\}}nstrumental {\{}V{\}}ariables in {\{}M{\}}odels with {\{}E{\}}ssential {\{}H{\}}eterogeneity}},
+title = {{Understanding Instrumental Variables in Models with Essential Heterogeneity}},
 volume = {88},
 year = {2006}
 }
 @incollection{Heckman.2001d,
 address = {Cambridge, United Kingdom},
 author = {Heckman, James J and Vytlacil, Edward J},
-booktitle = {{\{}N{\}}onlinear {\{}S{\}}tatistical {\{}M{\}}odeling: {\{}P{\}}roceedings of the {\{}T{\}}hirteenth {\{}I{\}}nternational {\{}S{\}}ymposium in {\{}E{\}}conomic {\{}T{\}}heory and {\{}E{\}}conometrics: {\{}E{\}}ssays in {\{}H{\}}onor of {\{}T{\}}akeshi {\{}A{\}}memiya},
+booktitle = {Nonlinear Statistical Modeling: Proceedings of the Thirteenth International Symposium in Economic Theory and Econometrics: Essays in Honor of Takeshi Amemiya},
 editor = {Hsiao, Cheng and Morimune, K and Powell, James},
 pages = {1--46},
 publisher = {Cambridge University Press},
-title = {{{\{}L{\}}ocal {\{}I{\}}nstrumental {\{}V{\}}ariables}},
+title = {{Local Instrumental Variables}},
 year = {2001}
 }
 @article{Heckman.2000,
@@ -6411,7 +6411,7 @@ author = {Heckman, James J and Vytlacil, Edward J},
 journal = {Economic Letters},
 number = {1},
 pages = {33--39},
-title = {{{\{}T{\}}he {\{}R{\}}elationship {\{}B{\}}etween {\{}T{\}}reatment {\{}P{\}}arameters within a {\{}L{\}}atent {\{}V{\}}ariable {\{}F{\}}ramework}},
+title = {{The Relationship Between Treatment Parameters within a Latent Variable Framework}},
 volume = {66},
 year = {2000}
 }
@@ -6420,29 +6420,29 @@ author = {Heckman, James J and Vytlacil, Edward J},
 journal = {Econometrica},
 number = {3},
 pages = {669--739},
-title = {{{\{}S{\}}tructural {\{}E{\}}quations, {\{}T{\}}reatment {\{}E{\}}ffects, and {\{}E{\}}conometric {\{}P{\}}olicy {\{}E{\}}valuation}},
+title = {{Structural Equations, Treatment Effects, and Econometric Policy Evaluation}},
 volume = {73},
 year = {2005}
 }
 @incollection{Heckman.2007e,
 address = {Amsterdam, Netherlands},
 author = {Heckman, James J and Vytlacil, Edward J},
-booktitle = {{\{}H{\}}andbook of {\{}E{\}}conometrics},
+booktitle = {Handbook of Econometrics},
 editor = {Heckman, James J and Leamer, Edward E},
 pages = {4779--4874},
 publisher = {Elsevier Science},
-title = {{{\{}E{\}}conometric {\{}E{\}}valuation of {\{}S{\}}ocial {\{}P{\}}rograms, {\{}P{\}}art {\{}I{\}}: {\{}C{\}}ausal {\{}E{\}}ffects, {\{}S{\}}tructural {\{}M{\}}odels and {\{}E{\}}conometric {\{}P{\}}olicy {\{}E{\}}valuation}},
+title = {{Econometric Evaluation of Social Programs, Part I: Causal Effects, Structural Models and Econometric Policy Evaluation}},
 volume = {6B},
 year = {2007}
 }
 @incollection{Heckman.2007f,
 address = {Amsterdam, Netherlands},
 author = {Heckman, James J and Vytlacil, Edward J},
-booktitle = {{\{}H{\}}andbook of {\{}E{\}}conometrics},
+booktitle = {Handbook of Econometrics},
 editor = {Heckman, James J and Leamer, Edward E},
 pages = {4875--5144},
 publisher = {Elsevier Science},
-title = {{{\{}E{\}}conometric {\{}E{\}}valuation of {\{}S{\}}ocial {\{}P{\}}rograms, {\{}P{\}}art {\{}I{\}}{\{}I{\}}: {\{}U{\}}sing the {\{}M{\}}arginal {\{}T{\}}reatment {\{}E{\}}ffect to {\{}O{\}}rganize {\{}A{\}}lternative {\{}E{\}}conomic {\{}E{\}}stimators to {\{}E{\}}valuate {\{}S{\}}ocial {\{}P{\}}rograms and to {\{}F{\}}orecast their {\{}E{\}}ffects in {\{}N{\}}ew {\{}E{\}}nvironments}},
+title = {{Econometric Evaluation of Social Programs, Part II: Using the Marginal Treatment Effect to Organize Alternative Economic Estimators to Evaluate Social Programs and to Forecast their Effects in New Environments}},
 volume = {6B},
 year = {2007}
 }
@@ -6451,18 +6451,18 @@ author = {Heckman, James J and Vytlacil, Edward J},
 journal = {American Economic Review},
 number = {2},
 pages = {107--111},
-title = {{{\{}P{\}}olicy-{\{}R{\}}elvant {\{}T{\}}reatment {\{}E{\}}ffects}},
+title = {{Policy-Relvant Treatment Effects}},
 volume = {91},
 year = {2001}
 }
 @incollection{Heckman.2001t,
 address = {Heidelberg, Germany},
 author = {Heckman, James J and Vytlacil, Edward J},
-booktitle = {{\{}E{\}}conometric {\{}E{\}}valuations of {\{}A{\}}ctive {\{}L{\}}abor {\{}M{\}}arket {\{}P{\}}olicies in {\{}E{\}}urope},
+booktitle = {Econometric Evaluations of Active Labor Market Policies in Europe},
 editor = {Lechner, Michael and Pfeiffer, Friedhelm},
 pages = {1--15},
 publisher = {Physica Verlag},
-title = {{{\{}I{\}}nsturmental {\{}V{\}}ariables, {\{}S{\}}election {\{}M{\}}odels, and {\{}T{\}}ight {\{}B{\}}ounds on the {\{}A{\}}verage {\{}T{\}}reatment {\{}E{\}}ffect}},
+title = {{Insturmental Variables, Selection Models, and Tight Bounds on the Average Treatment Effect}},
 year = {2001}
 }
 @article{Heckman.1990a,
@@ -6497,14 +6497,14 @@ year = {2002}
 @article{Heineck.2008,
 author = {Heineck, Guido and Anger, Silke},
 journal = {SOEPpapers},
-title = {{{\{}T{\}}he {\{}R{\}}eturns to {\{}C{\}}ognitive {\{}A{\}}bilities and {\{}P{\}}ersonality {\{}T{\}}raits in {\{}G{\}}ermany}},
+title = {{The Returns to Cognitive Abilities and Personality Traits in Germany}},
 volume = {124},
 year = {2008}
 }
 @article{Heineck.2007,
 author = {Heineck, Guido and Riphahn, Regina T},
 journal = {IZA Discussion Paper},
-title = {{{\{}I{\}}ntergenerational {\{}T{\}}ransmission of {\{}E{\}}ducational {\{}A{\}}ttainment in {\{}G{\}}ermany: {\{}T{\}}he {\{}L{\}}ast {\{}F{\}}ive {\{}D{\}}ecades}},
+title = {{Intergenerational Transmission of Educational Attainment in Germany: The Last Five Decades}},
 volume = {No. 2985},
 year = {2007}
 }
@@ -6521,7 +6521,7 @@ year = {1983}
 address = {Denver, CO},
 editor = {Helburn, Suzanne W},
 publisher = {Economics Department, University of Colorado at Denver},
-title = {{{\{}C{\}}ost, {\{}Q{\}}uality and {\{}C{\}}hild {\{}O{\}}utcomes in {\{}C{\}}hild {\{}C{\}}are {\{}C{\}}enters}},
+title = {{Cost, Quality and Child Outcomes in Child Care Centers}},
 year = {1995}
 }
 @article{Herbst.2012,
@@ -6534,7 +6534,7 @@ year = {2012}
 @article{Herbst.2009,
 author = {Herbst, Chris M and Tekin, Erdal},
 journal = {NBER Working Paper},
-title = {{{\{}C{\}}hild {\{}C{\}}are {\{}S{\}}ubsidies and {\{}C{\}}hildhood {\{}O{\}}besity}},
+title = {{Child Care Subsidies and Childhood Obesity}},
 volume = {15007},
 year = {2009}
 }
@@ -6542,17 +6542,17 @@ year = {2009}
 address = {New York, NY},
 author = {Herrnstein, Richard J and Murray, Charles A},
 publisher = {Free Press},
-title = {{{\{}T{\}}he {\{}B{\}}ell {\{}C{\}}urve: {\{}I{\}}ntelligence and {\{}C{\}}lass {\{}S{\}}tructure in {\{}A{\}}merican {\{}L{\}}ife}},
+title = {{The Bell Curve: Intelligence and Class Structure in American Life}},
 year = {1994}
 }
 @incollection{Hertz.2005,
 address = {Princeton, NJ},
 author = {Hertz, Tom},
-booktitle = {{\{}U{\}}nequal {\{}C{\}}hances: {\{}F{\}}amily {\{}B{\}}ackground and {\{}E{\}}conomic {\{}S{\}}uccess},
+booktitle = {Unequal Chances: Family Background and Economic Success},
 editor = {Bowles, Samuel and Gintis, Herbert and Osborne-Groves, Melissa},
 pages = {165--191},
 publisher = {Princeton University Press},
-title = {{{\{}R{\}}ags, {\{}R{\}}iches, and {\{}R{\}}ace: {\{}T{\}}he {\{}I{\}}ntergenerational {\{}E{\}}conomic {\{}M{\}}obiltiy of {\{}B{\}}lack and {\{}W{\}}hite {\{}F{\}}amilies in the {\{}U{\}}nited {\{}S{\}}tates}},
+title = {{Rags, Riches, and Race: The Intergenerational Economic Mobiltiy of Black and White Families in the United States}},
 year = {2005}
 }
 @book{Hilfen.2010,
@@ -6575,7 +6575,7 @@ author = {Hoderlein, Stefan and Mammen, Enno},
 journal = {Econometrica},
 number = {5},
 pages = {1513--1518},
-title = {{{\{}I{\}}dentification of {\{}M{\}}arginal {\{}E{\}}ffects in {\{}N{\}}onseparable {\{}M{\}}odels without {\{}M{\}}onotonicity}},
+title = {{Identification of Marginal Effects in Nonseparable Models without Monotonicity}},
 volume = {75},
 year = {2007}
 }
@@ -6583,16 +6583,16 @@ year = {2007}
 author = {Hoderlein, Stefan and Mammen, Enno},
 journal = {Econometrics Journal},
 pages = {1--25},
-title = {{{\{}I{\}}dentification and {\{}E{\}}stimation of {\{}L{\}}ocal {\{}A{\}}verage {\{}D{\}}erivatives in{\$}{\~{}}{\$}{\{}N{\}}on-{\{}S{\}}eparable{\$}{\~{}}{\$}{\{}M{\}}odels without {\{}M{\}}onotonicity}},
+title = {{Identification and Estimation of Local Average Derivatives in Non-Separable Models without Monotonicity}},
 volume = {12},
 year = {2009}
 }
 @article{Hoge.1983,
 author = {Hoge, Robert D},
-journal = {Journal of Special{\$}{\~{}}{\$}Education},
+journal = {Journal of Special Education},
 number = {4},
 pages = {401--429},
-title = {{{\{}P{\}}sychometric {\{}P{\}}roperties of {\{}T{\}}eacher-{\{}J{\}}udgement {\{}M{\}}easures of {\{}P{\}}upil {\{}A{\}}ptitudes, {\{}C{\}}lassroom {\{}B{\}}ehaviros, and {\{}A{\}}chievement {\{}L{\}}evels}},
+title = {{Psychometric Properties of Teacher-Judgement Measures of Pupil Aptitudes, Classroom Behaviros, and Achievement Levels}},
 volume = {17},
 year = {1983}
 }
@@ -6601,7 +6601,7 @@ author = {Hoge, Robert D and Coladarci, Theodore},
 journal = {Review of Educational Research},
 number = {3},
 pages = {297--313},
-title = {{{\{}T{\}}eacher-{\{}B{\}}ased {\{}J{\}}udgements of {\{}A{\}}cademic {\{}A{\}}chievement: {\{}A{\}} {\{}R{\}}eview of {\{}L{\}}iterature}},
+title = {{Teacher-Based Judgements of Academic Achievement: A Review of Literature}},
 volume = {59},
 year = {1989}
 }
@@ -6610,7 +6610,7 @@ author = {Holgersson, Margareta and Jorner, Ulf},
 journal = {International Journal of Bio-Medical Computing},
 number = {5},
 pages = {367--392},
-title = {{{\{}D{\}}ecomposition of a {\{}M{\}}ixture into {\{}N{\}}ormal {\{}C{\}}omponents:{\$}{\~{}}{\$}{\{}A{\}} {\{}R{\}}eview}},
+title = {{Decomposition of a Mixture into Normal Components: A Review}},
 volume = {9},
 year = {1978}
 }
@@ -6619,7 +6619,7 @@ author = {Holland, Paul W},
 journal = {Journal of the American Statistical Association},
 number = {396},
 pages = {945--960},
-title = {{{\{}S{\}}tatistics and {\{}C{\}}ausal {\{}I{\}}nference}},
+title = {{Statistics and Causal Inference}},
 volume = {81},
 year = {1986}
 }
@@ -6634,7 +6634,7 @@ year = {2009}
 author = {Hong, Guanglei and Raudenbush, Stephen W},
 journal = {Journal of the American Statistical Association},
 number = {475},
-title = {{{\{}E{\}}valuating {\{}K{\}}indergarten {\{}R{\}}etention {\{}P{\}}olicy:{\$}{\~{}}{\$}{\{}A{\}} {\{}C{\}}ase {\{}S{\}}tudy of {\{}C{\}}ausal {\{}I{\}}nference for {\{}M{\}}ultilevel {\{}O{\}}bservational {\{}D{\}}ata}},
+title = {{Evaluating Kindergarten Retention Policy: A Case Study of Causal Inference for Multilevel Observational Data}},
 volume = {101},
 year = {2006}
 }
@@ -6642,7 +6642,7 @@ year = {2006}
 address = {New York, NY},
 editor = {Hood, W and Koopmans, T},
 publisher = {Wiley},
-title = {{{\{}S{\}}tudies in {\{}E{\}}conometric {\{}M{\}}ethod}},
+title = {{Studies in Econometric Method}},
 year = {1953}
 }
 @article{Hopkins2006,
@@ -6662,11 +6662,11 @@ year = {2006}
 @incollection{Horowitz.2001,
 address = {Amsterdam, NL},
 author = {Horowitz, Joel L},
-booktitle = {{\{}H{\}}andbook of {\{}E{\}}conometrics},
+booktitle = {Handbook of Econometrics},
 editor = {Heckman, James J and Leamer, Edward E},
 pages = {3159--36228},
 publisher = {Elsevier Science},
-title = {{{\{}T{\}}he {\{}B{\}}ootstrap}},
+title = {{The Bootstrap}},
 year = {2001}
 }
 @article{Horowitz2001,
@@ -6737,38 +6737,38 @@ year = {1994}
 address = {Cambridge, MA},
 editor = {Hsiao, Cheng and Maddala, Gangadharro S},
 publisher = {Cambridge University Press},
-title = {{{\{}A{\}}nalysis of {\{}P{\}}anels and {\{}L{\}}imited {\{}D{\}}ependent {\{}V{\}}ariable {\{}M{\}}odels in {\{}H{\}}onour of {\{}G{\}}. {\{}S{\}}. {\{}M{\}}addala}},
+title = {{Analysis of Panels and Limited Dependent Variable Models in Honour of G. S. Maddala}},
 year = {1999}
 }
 @book{Hsiao.1999,
 address = {Cambridge, MA},
 editor = {Hsiao, Cheng and Maddala, Gangadharro S},
 publisher = {Cambridge University Press},
-title = {{{\{}A{\}}nalysis of {\{}P{\}}anels and {\{}L{\}}imited {\{}D{\}}ependent {\{}V{\}}ariable {\{}M{\}}odels in {\{}H{\}}onour of {\{}G{\}}. {\{}S{\}}. {\{}M{\}}addala}},
+title = {{Analysis of Panels and Limited Dependent Variable Models in Honour of G. S. Maddala}},
 year = {1999}
 }
 @book{Hsiao.2001,
 address = {New York, NY},
 editor = {Hsiao, Cheng and Morimune, K and Powell, James},
 publisher = {Cambridge University Press},
-title = {{{\{}N{\}}onlinear {\{}S{\}}tatistical {\{}M{\}}odeling: {\{}P{\}}roceedings of the {\{}T{\}}hirteenth {\{}I{\}}nternational {\{}S{\}}ymposium in {\{}E{\}}conomic {\{}T{\}}heory and {\{}E{\}}conometrics: {\{}E{\}}ssays in {\{}H{\}}onor of {\{}T{\}}akeshi {\{}A{\}}memiya}},
+title = {{Nonlinear Statistical Modeling: Proceedings of the Thirteenth International Symposium in Economic Theory and Econometrics: Essays in Honor of Takeshi Amemiya}},
 year = {2001}
 }
 @article{Hu.2006,
 author = {Hu, Yingyao and Schennach, Susanne},
 journal = {Working Paper},
-title = {{{\{}I{\}}dentification and {\{}E{\}}stimation of {\{}N{\}}onclassical {\{}N{\}}onlinear {\{}E{\}}rrors-in-{\{}V{\}}ariables {\{}M{\}}odels with {\{}C{\}}ontinuous {\{}D{\}}istributions using {\{}I{\}}nstruments}},
+title = {{Identification and Estimation of Nonclassical Nonlinear Errors-in-Variables Models with Continuous Distributions using Instruments}},
 volume = {The Univer},
 year = {2006}
 }
 @article{Hubner2010,
-author = {H{\"{u}}bner, Malte},
+author = {H\"{u}bner, Malte},
 doi = {10.1007/s10273-010-1063-z},
 issn = {0043-6275},
 journal = {Wirtschaftsdienst},
 number = {4},
 pages = {240--247},
-title = {{Das Wachstumsbeschleunigungsgesetz: Eine makro{\"{o}}konometrische Analyse}},
+title = {{Das Wachstumsbeschleunigungsgesetz: Eine makro\"{o}konometrische Analyse}},
 url = {http://www.springerlink.com/index/10.1007/s10273-010-1063-z},
 volume = {90},
 year = {2010}
@@ -6785,7 +6785,7 @@ year = {2011}
 @article{Huggett.2007,
 author = {Huggett, Mark and Ventura, Gustavo and Yaron, Amir},
 journal = {NBER Working Paper},
-title = {{{\{}S{\}}ources of {\{}L{\}}ifetime {\{}I{\}}nequality}},
+title = {{Sources of Lifetime Inequality}},
 volume = {13224},
 year = {2007}
 }
@@ -6800,13 +6800,13 @@ author = {Hunt, Jennifer},
 journal = {Journal of Labor Economics},
 number = {1},
 pages = {148--169},
-title = {{{\{}T{\}}he {\{}T{\}}ransition in {\{}E{\}}ast {\{}G{\}}ermany: {\{}W{\}}hen is a {\{}T{\}}en-{\{}P{\}}oint {\{}F{\}}all in the {\{}G{\}}ender {\{}W{\}}age {\{}G{\}}ap {\{}B{\}}ad {\{}N{\}}ews?}},
+title = {{The Transition in East Germany: When is a Ten-Point Fall in the Gender Wage Gap Bad News?}},
 volume = {20},
 year = {2002}
 }
 @article{Hunter.2007,
 author = {Hunter, John D},
-journal = {Computing in Science {\&} Engineering},
+journal = {Computing in Science \& Engineering},
 number = {90},
 pages = {90--95},
 title = {{Matplotlib: A 2D Graphics Environment}},
@@ -6815,7 +6815,7 @@ year = {2007}
 }
 @article{Matplotlib.2007,
 author = {Hunter, John D},
-journal = {Computing in Science {\&} Engineering},
+journal = {Computing in Science \& Engineering},
 number = {3},
 pages = {90--95},
 title = {{Matplotlib: A 2D Graphics Environment}},
@@ -6825,11 +6825,11 @@ year = {2007}
 @incollection{Hurwicz.1962,
 address = {Stanford, CA},
 author = {Hurwicz, Leonid},
-booktitle = {{\{}L{\}}ogic, {\{}M{\}}ethodology and {\{}P{\}}hilosophy of {\{}S{\}}cience},
+booktitle = {Logic, Methodology and Philosophy of Science},
 editor = {Nagel, Ernest and Suppes, Patrik and Tarski, Alfred},
 pages = {232--239},
 publisher = {Stanford University Press},
-title = {{{\{}O{\}}n the {\{}S{\}}tructural {\{}F{\}}orm of {\{}I{\}}nterdependent {\{}S{\}}ystems}},
+title = {{On the Structural Form of Interdependent Systems}},
 year = {1962}
 }
 @article{Hurwicz.1951,
@@ -6845,7 +6845,7 @@ author = {Huttenlocher, Janellen and Haight, Wendy and Bryk, Anthony and Seltzer
 journal = {Developmental Psychology},
 number = {2},
 pages = {236--248},
-title = {{{\{}E{\}}arly {\{}V{\}}ocabulary {\{}G{\}}rowth:{\$}{\~{}}{\$}{\{}R{\}}elation to {\{}L{\}}anguage {\{}I{\}}nput and {\{}G{\}}ender}},
+title = {{Early Vocabulary Growth: Relation to Language Input and Gender}},
 volume = {27},
 year = {1991}
 }
@@ -6854,7 +6854,7 @@ author = {Huttenlocher, Janellen and Vasilyeva, Marina and Waterfall, Heidi R an
 journal = {Developmental Psychology},
 number = {5},
 pages = {1062--1083},
-title = {{{\{}T{\}}he {\{}V{\}}arieties of {\{}S{\}}peech to {\{}Y{\}}oung {\{}C{\}}hildren}},
+title = {{The Varieties of Speech to Young Children}},
 volume = {43},
 year = {2007}
 }
@@ -6894,7 +6894,7 @@ year = {1993}
 author = {Ichimura, Hidehiko},
 journal = {Journal of Econometrics},
 pages = {71--120},
-title = {{{\{}S{\}}emiparametric {\{}L{\}}east {\{}S{\}}quares ({\{}S{\}}{\{}L{\}}{\{}S{\}}) and weighted {\{}S{\}}{\{}L{\}}{\{}S{\}} estimation of {\{}S{\}}ingle {\{}I{\}}ndex {\{}M{\}}odels}},
+title = {{Semiparametric Least Squares (SLS) and weighted SLS estimation of Single Index Models}},
 volume = {58},
 year = {1993}
 }
@@ -6933,7 +6933,7 @@ author = {Imbens, Guido W},
 journal = {American Economic Review},
 number = {2},
 pages = {126--132},
-title = {{{\{}S{\}}ensitivity to {\{}E{\}}xogeneity {\{}A{\}}ssumptions in {\{}S{\}}ocial {\{}P{\}}rograms}},
+title = {{Sensitivity to Exogeneity Assumptions in Social Programs}},
 volume = {93},
 year = {2003}
 }
@@ -6942,7 +6942,7 @@ author = {Imbens, Guido W},
 journal = {Journal of Economic Literature},
 number = {2},
 pages = {399--423},
-title = {{{\{}B{\}}etter {\{}L{\}}{\{}A{\}}{\{}T{\}}{\{}E{\}} than {\{}N{\}}othing: {\{}S{\}}ome {\{}C{\}}omments on {\{}D{\}}eaton (2009) and {\{}H{\}}eckman {\&} {\{}U{\}}rzua (2009)}},
+title = {{Better LATE than Nothing: Some Comments on Deaton (2009) and Heckman \& Urzua (2009)}},
 volume = {48},
 year = {2010}
 }
@@ -6951,14 +6951,14 @@ author = {Imbens, Guido W and Angrist, Joshua D},
 journal = {Econometrica},
 number = {2},
 pages = {467--475},
-title = {{{\{}I{\}}dentification and {\{}E{\}}stimation of {\{}L{\}}ocal {\{}A{\}}verage {\{}T{\}}reatment {\{}E{\}}ffects}},
+title = {{Identification and Estimation of Local Average Treatment Effects}},
 volume = {62},
 year = {1994}
 }
 @article{Imbens.2002,
 author = {Imbens, Guido W and Newey, Whitney},
 journal = {NBER Technical Working Paper},
-title = {{{\{}I{\}}dentification and {\{}E{\}}stimation of {\{}T{\}}riangular {\{}S{\}}imultaneous {\{}E{\}}quation {\{}M{\}}odels}},
+title = {{Identification and Estimation of Triangular Simultaneous Equation Models}},
 volume = {285},
 year = {2002}
 }
@@ -6974,8 +6974,8 @@ year = {2009}
 @book{Inhelder.1958,
 address = {London, UK},
 author = {Inhelder, Baerbel and Piaget, Jean},
-publisher = {Routledge {\&} Kegan Paul},
-title = {{{\{}T{\}}he {\{}G{\}}rowth of {\{}L{\}}ogical {\{}T{\}}hinking from {\{}C{\}}hildhood to {\{}A{\}}dolescence}},
+publisher = {Routledge \& Kegan Paul},
+title = {{The Growth of Logical Thinking from Childhood to Adolescence}},
 year = {1958}
 }
 @article{Iyengar.2005,
@@ -6994,9 +6994,9 @@ title = {{Alternative Employment Strategies for Hard-to-Employ TANF Recipients: 
 year = {2012}
 }
 @article{Jantti.2006,
-author = {J{\"{a}}ntti, Markus and R{\o}ed, Knut and Naylor, Robin and Bj{\"{o}}rklund, Anders and Bratsberg, Bernt and Raaum, Oddbj{\"{o}}rn and {\"{O}}sterbacka, Eva and Erikson, Tor},
+author = {J\"{a}ntti, Markus and R{\o}ed, Knut and Naylor, Robin and Bj\"{o}rklund, Anders and Bratsberg, Bernt and Raaum, Oddbj\"{o}rn and \"{O}sterbacka, Eva and Erikson, Tor},
 journal = {IZA Discussion Paper},
-title = {{{\{}A{\}}merican {\{}E{\}}xceptionalism in a {\{}N{\}}ew {\{}L{\}}ight: {\{}A{\}} {\{}C{\}}omparison of {\{}I{\}}ntergenerational {\{}E{\}}arnings {\{}M{\}}obility in the {\{}N{\}}ordic {\{}C{\}}ountries, the {\{}U{\}}nited {\{}K{\}}ingdom and the {\{}U{\}}nited {\{}S{\}}tates}},
+title = {{American Exceptionalism in a New Light: A Comparison of Intergenerational Earnings Mobility in the Nordic Countries, the United Kingdom and the United States}},
 volume = {No. 1938},
 year = {2006}
 }
@@ -7027,7 +7027,7 @@ author = {Jenkins, Stephen},
 journal = {European Economic Review},
 number = {5},
 pages = {1149--1158},
-title = {{{\{}S{\}}napshots versus {\{}M{\}}ovies: {\{}L{\}}ifecycle {\{}B{\}}iases and the {\{}E{\}}stimation of {\{}I{\}}ntergenerational {\{}E{\}}arnings {\{}I{\}}nheritance}},
+title = {{Snapshots versus Movies: Lifecycle Biases and the Estimation of Intergenerational Earnings Inheritance}},
 volume = {31},
 year = {1987}
 }
@@ -7056,7 +7056,7 @@ year = {2010}
 address = {Westport, Connecticut},
 author = {Jensen, Arthur R},
 publisher = {Praeger},
-title = {{{\{}T{\}}he g {\{}F{\}}actor}},
+title = {{The g Factor}},
 year = {1998}
 }
 @article{Jia.2008,
@@ -7071,21 +7071,21 @@ year = {2008}
 @book{Joe.1997,
 address = {London, UK},
 author = {Joe, Harry},
-publisher = {Chapman {\&} Hall},
-title = {{{\{}M{\}}ultivariate {\{}M{\}}odels and {\{}D{\}}ependence {\{}C{\}}oncepts}},
+publisher = {Chapman \& Hall},
+title = {{Multivariate Models and Dependence Concepts}},
 year = {1997}
 }
 @book{John.2008,
 address = {New York, NY},
 editor = {John, Oliver P and Robins, Robert and Pervin, Lawrence A},
 publisher = {Guilford},
-title = {{{\{}H{\}}andbook of {\{}P{\}}ersonality:{\$}{\~{}}{\$}{\{}T{\}}heory and {\{}R{\}}eserach}},
+title = {{Handbook of Personality: Theory and Reserach}},
 year = {2008}
 }
 @article{Johnson.1996,
 author = {Johnson, Amy},
 journal = {Princeton: Mathematica Policy Research},
-title = {{{\{}A{\}}n {\{}E{\}}valuation of the {\{}L{\}}ong-{\{}T{\}}erm {\{}I{\}}mpacts of the {\{}S{\}}ponsor-{\{}A{\}}-{\{}S{\}}cholar {\{}P{\}}rogram on {\{}S{\}}tudent {\{}P{\}}erformance}},
+title = {{An Evaluation of the Long-Term Impacts of the Sponsor-A-Scholar Program on Student Performance}},
 year = {1996}
 }
 @article{Johnson.2013,
@@ -7107,7 +7107,7 @@ year = {2012}
 address = {Washington, D.C.},
 author = {{Jonaki Bose}},
 publisher = {U.S. Department of Education},
-title = {{{\{}U{\}}ser's {\{}M{\}}anual for the {\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}} {\{}L{\}}ongitudinal {\{}K{\}}indergarten-{\{}F{\}}irst {\{}G{\}}rade {\{}P{\}}ublic-{\{}U{\}}se {\{}D{\}}ata {\{}F{\}}iles and {\{}E{\}}lectronic {\{}C{\}}odebook}},
+title = {{User's Manual for the ECLS-K Longitudinal Kindergarten-First Grade Public-Use Data Files and Electronic Codebook}},
 year = {2002}
 }
 @article{Beauchamp.2011,
@@ -7128,11 +7128,11 @@ year = {2012}
 @incollection{Joreskog.1977,
 address = {New York, NY},
 author = {Joreskog, Karl G},
-booktitle = {{\{}A{\}}pplications of {\{}S{\}}tatistics},
+booktitle = {Applications of Statistics},
 editor = {Krishnaiah, P},
 pages = {265--287},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}S{\}}tructural {\{}E{\}}quations {\{}M{\}}odels in {\{}S{\}}ocial {\{}S{\}}cience:{\$}{\~{}}{\$}{\{}S{\}}pecification , {\{}E{\}}stimation, and {\{}T{\}}esting}},
+title = {{Structural Equations Models in Social Science: Specification , Estimation, and Testing}},
 year = {1977}
 }
 @article{Joreskog.1975,
@@ -7140,7 +7140,7 @@ author = {Joreskog, Karl G and Goldberger, Arthur S},
 journal = {Journal of the American Statistical Association},
 number = {351},
 pages = {631--639},
-title = {{{\{}E{\}}stimation of a {\{}M{\}}odel with {\{}M{\}}ultiple {\{}I{\}}ndicators and {\{}M{\}}ultiple {\{}C{\}}auses of a {\{}S{\}}ingle {\{}L{\}}atent {\{}V{\}}ariable}},
+title = {{Estimation of a Model with Multiple Indicators and Multiple Causes of a Single Latent Variable}},
 volume = {70},
 year = {1975}
 }
@@ -7148,7 +7148,7 @@ year = {1975}
 address = {Cambridge, MA},
 author = {Joreskog, Karl G and Sorbom, Dag},
 publisher = {Abt Books},
-title = {{{\{}A{\}}dvances in {\{}F{\}}actor {\{}A{\}}nalysis and {\{}S{\}}tructural {\{}E{\}}quation {\{}M{\}}odels}},
+title = {{Advances in Factor Analysis and Structural Equation Models}},
 year = {1979}
 }
 @article{Judd.1997,
@@ -7176,13 +7176,13 @@ year = {2011}
 author = {Kaestner, Robert},
 journal = {NBER Working Paper},
 number = {14924},
-title = {{{\{}A{\}}dolescent {\{}C{\}}ognitive and {\{}N{\}}on-{\{}C{\}}ognitive {\{}C{\}}orrelates of {\{}A{\}}dult {\{}H{\}}ealth}},
+title = {{Adolescent Cognitive and Non-Cognitive Correlates of Adult Health}},
 year = {2009}
 }
 @article{Kaestner.2009b,
 author = {Kaestner, Robert and Grossman, Michael and Yarnoff, Benjamin},
 journal = {NBER Working Paper},
-title = {{{\{}E{\}}ffects of {\{}W{\}}eight on {\{}A{\}}dolescent {\{}E{\}}ducational {\{}A{\}}ttainment}},
+title = {{Effects of Weight on Adolescent Educational Attainment}},
 volume = {14994},
 year = {2009}
 }
@@ -7197,7 +7197,7 @@ author = {Kane, Thomas and Rouse, Cecilia},
 journal = {American Economic Review},
 number = {3},
 pages = {600--614},
-title = {{{\{}L{\}}abor-{\{}M{\}}arket {\{}R{\}}eturns to {\{}T{\}}wo- and {\{}F{\}}our-{\{}Y{\}}ear {\{}C{\}}ollege}},
+title = {{Labor-Market Returns to Two- and Four-Year College}},
 volume = {85},
 year = {1995}
 }
@@ -7205,7 +7205,7 @@ year = {1995}
 address = {Washington, D.C.},
 author = {{Karen Tourangeau} and {Mick Brick} and {Lauren Byrne} and {Thanh Le} and {Christine Nord} and {Westat Jerry} and {West Elvira} and {Germino Hausken}},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-99 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}T{\}}hird {\{}G{\}}rade {\{}M{\}}ethodology {\{}R{\}}eport}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-99 (ECLS-K): Third Grade Methodology Report}},
 year = {2005}
 }
 @book{Karlin.1968,
@@ -7235,7 +7235,7 @@ year = {2011}
 address = {Santa Monica, CA},
 author = {Karoly, Lynn A and Greenwood, Peter W and Everingham, Susan S and Houb{\'{e}}, Jill and Kilburn, Rebecca M and Rydell, C Peter and Sanders, Matthew and Chiesa, James},
 publisher = {The RAND Corporation},
-title = {{{\{}I{\}}nvesting {\{}I{\}}n {\{}O{\}}ur {\{}C{\}}hildren: {\{}W{\}}hat {\{}W{\}}e {\{}K{\}}now 95 {\{}A{\}}nd {\{}D{\}}on't {\{}K{\}}now {\{}A{\}}bout {\{}T{\}}he {\{}C{\}}osts {\{}A{\}}nd {\{}B{\}}enefits {\{}O{\}}f {\{}E{\}}arly {\{}C{\}}hildhood {\{}I{\}}nterventions}},
+title = {{Investing In Our Children: What We Know 95 And Don't Know About The Costs And Benefits Of Early Childhood Interventions}},
 year = {1998}
 }
 @article{Kastoryano.2011,
@@ -7248,7 +7248,7 @@ volume = {No. 5424}
 author = {Katz, Lawrence F and Kling, Jeffrey R and Liebman, Jeffrey B},
 journal = {The Quarterly Journal of Economics},
 pages = {607--654},
-title = {{{\{}M{\}}oving to {\{}O{\}}pportunity in {\{}B{\}}oston: {\{}E{\}}arly {\{}R{\}}esults of a {\{}R{\}}andomized {\{}M{\}}obility {\{}E{\}}xperiment}},
+title = {{Moving to Opportunity in Boston: Early Results of a Randomized Mobility Experiment}},
 volume = {116},
 year = {2001}
 }
@@ -7263,16 +7263,16 @@ author = {Keane, Michael P},
 journal = {Journal of Econometrics},
 number = {1},
 pages = {3--20},
-title = {{{\{}S{\}}tructural vs. {\{}A{\}}theoretic {\{}A{\}}pproaches to {\{}E{\}}conometrics}},
+title = {{Structural vs. Atheoretic Approaches to Econometrics}},
 volume = {156},
 year = {2010}
 }
 @article{Keane.1992,
 author = {Keane, Michael P},
-journal = {Journal of Business {\&} Economic Statistics},
+journal = {Journal of Business \& Economic Statistics},
 number = {2},
 pages = {193--200},
-title = {{{\{}A{\}} {\{}N{\}}ote on {\{}I{\}}dentification in the {\{}M{\}}ultinomial {\{}P{\}}robit {\{}M{\}}odel}},
+title = {{A Note on Identification in the Multinomial Probit Model}},
 volume = {10},
 year = {1992}
 }
@@ -7291,11 +7291,11 @@ year = {2010}
 @incollection{Keane.2011d,
 address = {Amsterdam, Netherlands},
 author = {Keane, Michael P and Todd, Petra E and Wolpin, Kenneth I},
-booktitle = {Hanbook of Labor Economics},
+booktitle = {Handbook of Labor Economics},
 editor = {Ashenfelter, Orley and Card, David},
 pages = {331--461},
 publisher = {Elsevier Science},
-title = {{{\{}T{\}}he {\{}S{\}}tructural {\{}E{\}}stimation of {\{}B{\}}ehavioral {\{}M{\}}odels: {\{}D{\}}iscrete {\{}C{\}}hoice {\{}D{\}}ynamic {\{}P{\}}rogramming {\{}M{\}}ethods and {\{}A{\}}pplications}},
+title = {{The Structural Estimation of Behavioral Models: Discrete Choice Dynamic Programming Methods and Applications}},
 volume = {4A},
 year = {2011}
 }
@@ -7373,7 +7373,7 @@ year = {1994}
 address = {New York, NY},
 editor = {Keating, Daniel P and Hertzman, Clyde},
 publisher = {The Guilford Press},
-title = {{{\{}D{\}}evelopmental {\{}H{\}}ealth and the {\{}W{\}}ealth of {\{}N{\}}ations: {\{}S{\}}ocial, {\{}B{\}}iological, and {\{}E{\}}ducational {\{}D{\}}ynamics}},
+title = {{Developmental Health and the Wealth of Nations: Social, Biological, and Educational Dynamics}},
 year = {1999}
 }
 @article{Kelder1994,
@@ -7386,7 +7386,7 @@ number = {7},
 pages = {1121--1126},
 pmid = {8017536},
 title = {{Longitudinal tracking of adolescent smoking, physical activity, and food choice behaviors.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1614729{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1614729&tool=pmcentrez&rendertype=abstract},
 volume = {84},
 year = {1994}
 }
@@ -7435,7 +7435,7 @@ author = {Kenkel, Donald S},
 journal = {Journal of Political Economy},
 number = {2},
 pages = {287--305},
-title = {{{\{}H{\}}ealth {\{}B{\}}ehavior,{\$}{\~{}}{\$}{\{}H{\}}ealth {\{}K{\}}nowledge, and {\{}S{\}}chooling}},
+title = {{Health Behavior, Health Knowledge, and Schooling}},
 volume = {99},
 year = {1991}
 }
@@ -7468,7 +7468,7 @@ year = {1921}
 @book{King.2016,
 address = {London, UK},
 author = {King, Mervyn},
-publisher = {W. W. Norton {\&} Company},
+publisher = {W. W. Norton \& Company},
 title = {{The End of Alchemy: Money, Banking and the Future of the Global Economy}},
 year = {2016}
 }
@@ -7484,13 +7484,13 @@ year = {2004}
 @article{Klein.2009,
 author = {Klein, Roger W and Shen, Chan and Vella, Francis},
 journal = {Working Paper},
-title = {{{\{}T{\}}riangular {\{}S{\}}emiparametric {\{}M{\}}odels {\{}F{\}}eaturing {\{}T{\}}wo {\{}D{\}}ependent {\{}E{\}}ndogenous {\{}B{\}}inary {\{}O{\}}utcomes}},
+title = {{Triangular Semiparametric Models Featuring Two Dependent Endogenous Binary Outcomes}},
 year = {2009}
 }
 @article{Klein.2010,
 author = {Klein, Tobias},
 journal = {Journal of Econometrics},
-title = {{{\{}H{\}}eterogeneous {\{}T{\}}reatment {\{}E{\}}ffects: {\{}I{\}}nstrumental {\{}V{\}}ariables {\{}W{\}}ithout {\{}M{\}}onotonicity?}},
+title = {{Heterogeneous Treatment Effects: Instrumental Variables Without Monotonicity?}},
 year = {2010}
 }
 @book{Klemens.2008,
@@ -7513,7 +7513,7 @@ address = {London, UK},
 author = {Kline, Paul},
 isbn = {0415094895},
 publisher = {Routledge},
-title = {{{\{}A{\}}n {\{}E{\}}asy {\{}G{\}}uide to {\{}F{\}}actor {\{}A{\}}nalysis}},
+title = {{An Easy Guide to Factor Analysis}},
 year = {1994}
 }
 @article{Kling.2001,
@@ -7521,7 +7521,7 @@ author = {Kling, Jeffrey R},
 journal = {Journal of Business and Economic Statistics},
 number = {3},
 pages = {358--364},
-title = {{{\{}I{\}}nterpreting {\{}I{\}}nstrumental {\{}V{\}}ariables {\{}E{\}}stimates of the {\{}R{\}}eturns to {\{}S{\}}chooling}},
+title = {{Interpreting Instrumental Variables Estimates of the Returns to Schooling}},
 volume = {19},
 year = {2001}
 }
@@ -7530,7 +7530,7 @@ author = {Kling, Jeffrey R and Liebman, Jeffrey B and Katz, Lawrence F},
 journal = {Econometrica},
 number = {1},
 pages = {83--119},
-title = {{{\{}E{\}}xperimental {\{}A{\}}nalysis of {\{}N{\}}eighborhood {\{}E{\}}ffects}},
+title = {{Experimental Analysis of Neighborhood Effects}},
 volume = {75},
 year = {2007}
 }
@@ -7546,7 +7546,7 @@ author = {Knudsen, Eric I and Heckman, James J and Cameron, Judy and Shonkoff, J
 journal = {Proceedings of the National Academy of Science},
 number = {27},
 pages = {10155--10162},
-title = {{{\{}E{\}}conomic, {\{}N{\}}eurobiological , and {\{}B{\}}ehavioral {\{}P{\}}erspectives on {\{}B{\}}uilding {\{}A{\}}merica's {\{}F{\}}uture {\{}W{\}}orkforce}},
+title = {{Economic, Neurobiological , and Behavioral Perspectives on Building America's Future Workforce}},
 volume = {103},
 year = {2006}
 }
@@ -7597,14 +7597,14 @@ year = {2007}
 @article{Wild.2007,
 author = {Kopczuk, Wojciech and Saez, Emmanuel and Song, Jae},
 journal = {NBER Working Paper},
-title = {{{\{}U{\}}ncovering the {\{}A{\}}merican {\{}D{\}}ream: {\{}I{\}}nequality and {\{}M{\}}obility in {\{}S{\}}ocial {\{}S{\}}ecurity {\{}E{\}}arnings {\{}D{\}}ata}},
+title = {{Uncovering the American Dream: Inequality and Mobility in Social Security Earnings Data}},
 volume = {13345},
 year = {2007}
 }
 @article{Kopczuk.2007,
 author = {Kopczuk, Wojciech and Saez, Emmanuel and Song, Jae},
 journal = {NBER Working Paper},
-title = {{{\{}U{\}}ncovering the {\{}A{\}}merican {\{}D{\}}ream: {\{}I{\}}nequality and {\{}M{\}}obility in {\{}S{\}}ocial {\{}S{\}}ecurity {\{}E{\}}arnings {\{}D{\}}ata}},
+title = {{Uncovering the American Dream: Inequality and Mobility in Social Security Earnings Data}},
 volume = {13345},
 year = {2007}
 }
@@ -7625,7 +7625,7 @@ year = {2010}
 address = {Washington, D.C.},
 editor = {Kosters, Martin},
 publisher = {American Enterprise Institute Press},
-title = {{{\{}F{\}}inancing {\{}C{\}}ollege {\{}T{\}}uition: {\{}G{\}}overnment {\{}P{\}}olicies and {\{}E{\}}ducational {\{}P{\}}riorities}},
+title = {{Financing College Tuition: Government Policies and Educational Priorities}},
 year = {1999}
 }
 @article{Kotlarski.1967,
@@ -7633,7 +7633,7 @@ author = {Kotlarski, Ignacy},
 journal = {Pacific Journal of Mathematics},
 number = {1},
 pages = {69--76},
-title = {{{\{}O{\}}n {\{}C{\}}haracterizing the {\{}G{\}}amma and the {\{}N{\}}ormal {\{}D{\}}istribution}},
+title = {{On Characterizing the Gamma and the Normal Distribution}},
 volume = {20},
 year = {1967}
 }
@@ -7642,7 +7642,7 @@ author = {Kramer, Michael S and Shapiro, Stanley},
 journal = {Journal of the American Medical Association},
 number = {16},
 pages = {2739--2745},
-title = {{{\{}S{\}}cientific {\{}C{\}}hallenges in the {\{}A{\}}pplication of {\{}R{\}}andomized {\$}{\~{}}{\$}{\{}T{\}}rials}},
+title = {{Scientific Challenges in the Application of Randomized  Trials}},
 volume = {252},
 year = {1984}
 }
@@ -7651,7 +7651,7 @@ author = {Krein, Sheila Fitzgerald and Beller, Andrea H},
 journal = {Demography},
 number = {2},
 pages = {221--234},
-title = {{{\{}E{\}}ducational {\{}A{\}}ttainment of {\{}C{\}}hildren from {\{}S{\}}ingle-{\{}P{\}}arent {\{}F{\}}amilies: {\{}D{\}}ifferences by {\{}E{\}}xposure, {\{}G{\}}ender, and {\{}R{\}}ace}},
+title = {{Educational Attainment of Children from Single-Parent Families: Differences by Exposure, Gender, and Race}},
 volume = {25},
 year = {1998}
 }
@@ -7678,7 +7678,7 @@ year = {1990}
 address = {New York, NY},
 editor = {Krishnaiah, P},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}A{\}}pplications of {\{}S{\}}tatistics}},
+title = {{Applications of Statistics}},
 year = {1977}
 }
 @unpublished{Salanie.2013,
@@ -7722,7 +7722,7 @@ year = {1964}
 @article{LaCroix.2007,
 author = {{La Croix}, David and Doepke, Matthias},
 journal = {NBER Working Paper},
-title = {{{\{}T{\}}o {\{}S{\}}egregate or to {\{}I{\}}ntegrate: {\{}E{\}}ducation {\{}P{\}}olicies and {\{}D{\}}emocracy}},
+title = {{To Segregate or to Integrate: Education Policies and Democracy}},
 volume = {13319},
 year = {2007}
 }
@@ -7730,14 +7730,14 @@ year = {2007}
 address = {New York, NY},
 author = {{La Fuente}, Angel},
 publisher = {Cambridge University Press},
-title = {{{\{}M{\}}athematical {\{}M{\}}ethods and {\{}M{\}}odels for {\{}E{\}}conomists}},
+title = {{Mathematical Methods and Models for Economists}},
 year = {2000}
 }
 @article{Ladd.1999,
 author = {Ladd, Gary W and Birch, Sondra H and Buhs, Eric S},
 journal = {Child Development},
 pages = {1373--1400},
-title = {{{\{}C{\}}hildren's {\{}S{\}}ocial and {\{}S{\}}cholastic {\{}L{\}}ives in {\{}K{\}}indergarten: {\{}R{\}}elated {\{}S{\}}pheres of {\{}I{\}}nfluence?}},
+title = {{Children's Social and Scholastic Lives in Kindergarten: Related Spheres of Influence?}},
 volume = {70},
 year = {1999}
 }
@@ -7746,7 +7746,7 @@ author = {Laferrere, Anne},
 journal = {The Geneva Papers on Risk and Insurance - Issues and Practice},
 number = {1},
 pages = {2--26},
-title = {{{\{}I{\}}ntergenerational {\{}T{\}}ransmission {\{}M{\}}odels: {\{}A{\}} {\{}S{\}}urvey}},
+title = {{Intergenerational Transmission Models: A Survey}},
 volume = {24},
 year = {1999}
 }
@@ -7766,22 +7766,22 @@ author = {LaLonde, Robert},
 journal = {American Economic Review},
 number = {4},
 pages = {604--620},
-title = {{{\{}E{\}}valuating the {\{}E{\}}conometric {\{}E{\}}valuation of {\{}T{\}}raining {\{}P{\}}rograms with {\{}E{\}}xperimental {\{}D{\}}ata}},
+title = {{Evaluating the Econometric Evaluation of Training Programs with Experimental Data}},
 volume = {76},
 year = {1986}
 }
 @article{Lang.2005,
 author = {Lang, Frieder R},
 journal = {DIW Research Notes},
-title = {{{\{}E{\}}rfassung des kognitiven {\{}L{\}}eistungspotentials und der ''{\{}B{\}}ig {\{}F{\}}ive'' mit {\{}C{\}}omputer-{\{}A{\}}ssisted-{\{}P{\}}ersonal-{\{}I{\}}nterviewing ({\{}C{\}}{\{}A{\}}{\{}P{\}}{\{}I{\}}):{\$}{\~{}}{\$}{\{}Z{\}}ur {\{}R{\}}eliabilit{\"{a}}t und {\{}V{\}}alidit{\"{a}}t zweier ultrakurzer {\{}T{\}}ests and des {\{}B{\}}{\{}F{\}}{\{}I{\}}-{\{}S{\}}}},
+title = {{Erfassung des kognitiven Leistungspotentials und der ''Big Five'' mit Computer-Assisted-Personal-Interviewing (CAPI): Zur Reliabilit\"{a}t und Validit\"{a}t zweier ultrakurzer Tests and des BFI-S}},
 volume = {5},
 year = {2005}
 }
 @article{Lang.2007,
-author = {Lang, Frieder R and Weiss, David and Stocker, Andreas von{\$}{\~{}}{\$}Rosenbladt Bernhard},
+author = {Lang, Frieder R and Weiss, David and Stocker, Andreas von Rosenbladt Bernhard},
 journal = {Schmollers Jahrbuch},
 pages = {183--192},
-title = {{{\{}A{\}}ssessing {\{}C{\}}ognitive {\{}C{\}}apacities in{\$}{\~{}}{\$}{\{}C{\}}omputer-{\{}A{\}}ssisted {\{}S{\}}urvey {\{}R{\}}esearch:{\$}{\~{}}{\$}{\{}T{\}}wo {\{}U{\}}ltra-{\{}S{\}}hort {\{}T{\}}ests of {\{}I{\}}ntellectual {\{}A{\}}bility in the {\{}G{\}}erman {\{}S{\}}ocio-{\{}E{\}}conomic {\{}P{\}}anel ({\{}S{\}}{\{}O{\}}{\{}E{\}}{\{}P{\}})}},
+title = {{Assessing Cognitive Capacities in Computer-Assisted Survey Research: Two Ultra-Short Tests of Intellectual Ability in the German Socio-Economic Panel (SOEP)}},
 volume = {127},
 year = {2007}
 }
@@ -7790,14 +7790,14 @@ author = {Lang, Kevin and Zagorsky, Jay},
 journal = {Journal of Human Resources},
 number = {2},
 pages = {253--273},
-title = {{{\{}D{\}}oes {\{}G{\}}rowing {\{}U{\}}p {\{}W{\}}ith a {\{}P{\}}arent {\{}A{\}}bsent {\{}R{\}}eally {\{}H{\}}urt?}},
+title = {{Does Growing Up With a Parent Absent Really Hurt?}},
 volume = {36},
 year = {2001}
 }
 @article{Lange.2008,
 author = {Lange, Fabian and Bharadwaj, Prashant and Altonji, Joseph G},
 journal = {NBER Working Paper},
-title = {{{\{}C{\}}hanges in the {\{}C{\}}haracteristics of {\{}A{\}}merican{\$}{\~{}}{\$}{\{}Y{\}}outh :{\$}{\~{}}{\$}{\{}I{\}}mplications for {\{}A{\}}dult {\{}O{\}}utcomes}},
+title = {{Changes in the Characteristics of American Youth : Implications for Adult Outcomes}},
 volume = {13883},
 year = {2008}
 }
@@ -7835,7 +7835,7 @@ author = {Layzer, Jean I and Goodson, Barbara D},
 journal = {Evaluation Review},
 number = {5},
 pages = {556--576},
-title = {{{\{}T{\}}he ''{\{}Q{\}}uality'' of {\{}E{\}}arly {\{}C{\}}are and {\{}E{\}}ducation {\{}S{\}}ettings: {\{}D{\}}efinitional and {\{}M{\}}easurement {\{}I{\}}ssues}},
+title = {{The ''Quality'' of Early Care and Education Settings: Definitional and Measurement Issues}},
 volume = {30},
 year = {2006}
 }
@@ -7844,7 +7844,7 @@ author = {Lazear, Edward P},
 journal = {American Economic Review},
 number = {4},
 pages = {606--620},
-title = {{{\{}A{\}}gency, {\{}E{\}}arnings {\{}P{\}}rofiles, {\{}P{\}}roductivity, and {\{}H{\}}ours {\{}R{\}}estrictions}},
+title = {{Agency, Earnings Profiles, Productivity, and Hours Restrictions}},
 volume = {71},
 year = {1981}
 }
@@ -7877,7 +7877,7 @@ year = {2005}
 }
 @article{Lechner.2009a,
 author = {Lechner, M},
-journal = {Journal of Business {\&} Economic Statistics},
+journal = {Journal of Business \& Economic Statistics},
 number = {1},
 pages = {71--83},
 title = {{Sequential Causal Models for the Evaluation of Labor Market Programs}},
@@ -7903,10 +7903,10 @@ volume = {28},
 year = {2009}
 }
 @book{Lechner.2001,
-address = {Heiderlbert,{\$}{\~{}}{\$}Germany},
+address = {Heiderlbert, Germany},
 editor = {Lechner, Michael and Pfeiffer, Friedhelm},
 publisher = {Physica Verlag},
-title = {{{\{}E{\}}conometric {\{}E{\}}valuations of {\{}A{\}}ctive {\{}L{\}}abor {\{}M{\}}arket {\{}P{\}}olicies in {\{}E{\}}urope}},
+title = {{Econometric Evaluations of Active Labor Market Policies in Europe}},
 year = {2001}
 }
 @article{Lee.1991,
@@ -7941,7 +7941,7 @@ author = {Lee, Donghoon and Wolpin, Kenneth I},
 journal = {Journal of Econometrics},
 number = {1},
 pages = {68--85},
-title = {{Accounting for Wage and Employment Changes in the {\{}U{\}}{\{}S{\}} from 1968--2000: A Dynamic Model of Labor Market Equilibrium}},
+title = {{Accounting for Wage and Employment Changes in the US from 1968--2000: A Dynamic Model of Labor Market Equilibrium}},
 volume = {156},
 year = {2010}
 }
@@ -7968,7 +7968,7 @@ author = {Lee, Lung-Fei},
 journal = {Econometrica},
 number = {2},
 pages = {507--512},
-title = {{{\{}G{\}}eneralized {\{}E{\}}conometric {\{}M{\}}odels with {\{}S{\}}electivity}},
+title = {{Generalized Econometric Models with Selectivity}},
 volume = {51},
 year = {1983}
 }
@@ -7998,7 +7998,7 @@ author = {Leibowitz, Arleen},
 journal = {The Journal of Human Resources},
 number = {2},
 pages = {242--251},
-title = {{{\{}P{\}}arental {\{}I{\}}nputs and {\{}C{\}}hildren's {\{}A{\}}chievement}},
+title = {{Parental Inputs and Children's Achievement}},
 volume = {12},
 year = {1977}
 }
@@ -8007,7 +8007,7 @@ author = {Leibowitz, Arleen},
 journal = {The Journal of Political Economy},
 number = {2},
 pages = {S111----S131},
-title = {{{\{}H{\}}ome {\{}I{\}}nvestments in {\{}C{\}}hildren}},
+title = {{Home Investments in Children}},
 volume = {82},
 year = {1974}
 }
@@ -8024,7 +8024,7 @@ author = {Levitt, Pat},
 journal = {Journal of Pediatrics},
 number = {4},
 pages = {35--45},
-title = {{{\{}S{\}}tructural and {\{}F{\}}unctional {\{}M{\}}aturation of the {\{}D{\}}eveloping {\{}P{\}}rimate {\{}B{\}}rain}},
+title = {{Structural and Functional Maturation of the Developing Primate Brain}},
 volume = {143},
 year = {2003}
 }
@@ -8033,27 +8033,27 @@ address = {Hoboken, NJ},
 author = {Leyffer, Sven and Mahajan, Ashutosh},
 booktitle = {Wiley Encyclopedia of Operations Research and Management Science},
 editor = {Cochran, James J and Cox, Louis A and Keskinocak, Pinar and Kharoufeh, Jeffrey P and Smith, J Cole},
-publisher = {John Wiley {\&} Sons, Inc.},
+publisher = {John Wiley \& Sons, Inc.},
 title = {{Software For Nonlinearly Constrained Optimization}},
 year = {2010}
 }
 @article{Li.2002b,
 author = {Li, Mingliang and Poirier, Dale J and Tobias, Justin L},
 journal = {Working Paper},
-title = {{{\{}D{\}}o {\{}D{\}}ropouts {\{}S{\}}uffer from {\{}D{\}}ropping {\{}O{\}}ut? {\{}E{\}}stimation and {\{}P{\}}rediction of {\{}O{\}}utcome {\{}G{\}}ains in {\{}G{\}}eneralized {\{}S{\}}election {\{}M{\}}odels}},
+title = {{Do Dropouts Suffer from Dropping Out? Estimation and Prediction of Outcome Gains in Generalized Selection Models}},
 year = {2002}
 }
 @article{Li.2005,
 author = {Li, Mingliang and Tobias, Justin L},
 journal = {Working Paper},
-title = {{{\{}B{\}}ayesian {\{}A{\}}nalysis of {\{}T{\}}reatment {\{}E{\}}ffects in an {\{}O{\}}rdered {\{}P{\}}otential {\{}O{\}}utcomes {\{}M{\}}odel}},
+title = {{Bayesian Analysis of Treatment Effects in an Ordered Potential Outcomes Model}},
 year = {2005}
 }
 @article{Li.2002,
 author = {Li, Tong},
 journal = {Journal of Econometrics},
 pages = {1--26},
-title = {{{\{}R{\}}obust and {\{}C{\}}onsistent {\{}E{\}}stimation of {\{}N{\}}onlinear {\{}E{\}}rrors-{\{}I{\}}n-{\{}V{\}}ariables {\{}M{\}}odels}},
+title = {{Robust and Consistent Estimation of Nonlinear Errors-In-Variables Models}},
 volume = {110},
 year = {2002}
 }
@@ -8080,7 +8080,7 @@ author = {Li, Tong and Vuong, Quang},
 journal = {Journal of Multivariate Analysis},
 number = {2},
 pages = {139--165},
-title = {{{\{}N{\}}onparametric {\{}E{\}}stimation of the {\{}M{\}}easurement {\{}E{\}}rror {\{}M{\}}odel {\{}U{\}}sing {\{}M{\}}ultiple {\{}I{\}}ndicators}},
+title = {{Nonparametric Estimation of the Measurement Error Model Using Multiple Indicators}},
 volume = {65},
 year = {1998}
 }
@@ -8089,7 +8089,7 @@ author = {Lien, N and Lytle, Leslie A and Klepp, Knut-Inge},
 journal = {Preventive Medicine},
 number = {3},
 pages = {217--226},
-title = {{{\{}S{\}}tability in {\{}C{\}}onsumption of {\{}F{\}}ruit, {\{}V{\}}egetables, and {\{}S{\}}ugary {\{}F{\}}oods in a {\{}C{\}}ohort from {\{}A{\}}ge 14 to {\{}A{\}}ge 21}},
+title = {{Stability in Consumption of Fruit, Vegetables, and Sugary Foods in a Cohort from Age 14 to Age 21}},
 volume = {33},
 year = {2001}
 }
@@ -8119,7 +8119,7 @@ year = {2004}
 address = {New York, NY},
 author = {Liu, Jun S},
 publisher = {Springer},
-title = {{{\{}M{\}}onte {\{}C{\}}arlo{\$}{\~{}}{\$}{\{}S{\}}trategies in {\{}S{\}}cientific {\{}C{\}}omputing}},
+title = {{Monte Carlo Strategies in Scientific Computing}},
 year = {2008}
 }
 @article{Liu.2000,
@@ -8127,7 +8127,7 @@ author = {Liu, Jun S and Sabatti, Chiara},
 journal = {Biometrika},
 number = {2},
 pages = {353--369},
-title = {{{\{}G{\}}eneralized {\{}G{\}}ibbs {\{}S{\}}ampler and {\{}M{\}}ultigrid {\{}M{\}}onte {\{}C{\}}arlo for {\{}B{\}}ayesian {\{}C{\}}omputation}},
+title = {{Generalized Gibbs Sampler and Multigrid Monte Carlo for Bayesian Computation}},
 volume = {87},
 year = {2000}
 }
@@ -8148,7 +8148,7 @@ author = {Lizzeri, Alessandro and Siniscalchi, Marciano},
 journal = {The Quarterly Journal of Economics},
 number = {3},
 pages = {1161--1195},
-title = {{{\{}P{\}}arental {\{}G{\}}uidance and {\{}S{\}}upervised {\{}L{\}}earning}},
+title = {{Parental Guidance and Supervised Learning}},
 volume = {123},
 year = {2008}
 }
@@ -8156,7 +8156,7 @@ year = {2008}
 author = {Lleras-Muney, Adriana and Lichenberg, Frank R},
 journal = {NBER Working Paper},
 number = {9185},
-title = {{{\{}T{\}}he {\{}E{\}}ffect of {\{}E{\}}ducation on {\{}M{\}}edical {\{}T{\}}echnology {\{}A{\}}doption:{\$}{\~{}}{\$}{\{}A{\}}re the {\{}M{\}}ore {\{}E{\}}ducated {\{}M{\}}ore {\{}L{\}}ikely to {\{}U{\}}se new {\{}D{\}}rugs?}},
+title = {{The Effect of Education on Medical Technology Adoption: Are the More Educated More Likely to Use new Drugs?}},
 year = {2002}
 }
 @article{Loeb2007,
@@ -8177,7 +8177,7 @@ author = {Loeb, Susanna and Bridges, Margaret and Bassok, Daphna and Fuller, Bru
 journal = {Economic of Education Review},
 number = {1},
 pages = {52--66},
-title = {{{\{}H{\}}ow {\{}M{\}}uch is too {\{}M{\}}uch? {\{}T{\}}he {\{}I{\}}nfluence of {\{}P{\}}reschool {\{}C{\}}enters on {\{}C{\}}hildren's {\{}S{\}}ocial and {\{}C{\}}ognitive {\{}D{\}}evelopment}},
+title = {{How Much is too Much? The Influence of Preschool Centers on Children's Social and Cognitive Development}},
 volume = {26},
 year = {2007}
 }
@@ -8185,14 +8185,14 @@ year = {2007}
 address = {Mahwah, NJ},
 author = {Loehlin, John C},
 publisher = {Erlbaum},
-title = {{{\{}L{\}}atent {\{}V{\}}ariable {\{}M{\}}odels: {\{}A{\}}n {\{}I{\}}ntroduction to {\{}F{\}}actor, {\{}P{\}}ath, and {\{}S{\}}tructural {\{}E{\}}quation {\{}A{\}}nalysis}},
+title = {{Latent Variable Models: An Introduction to Factor, Path, and Structural Equation Analysis}},
 year = {2004}
 }
 @book{Lord.1968,
 address = {Reading, MA},
 editor = {Lord, Frederic M and Novick, Melvin R},
 publisher = {Addison-Wesley},
-title = {{{\{}S{\}}tatistical {\{}T{\}}heories of {\{}M{\}}ental {\{}T{\}}est {\{}S{\}}cores}},
+title = {{Statistical Theories of Mental Test Scores}},
 year = {1968}
 }
 @article{Loughran.2008,
@@ -8200,7 +8200,7 @@ author = {Loughran, David S and Datar, Ashlesha and Kilburn, Rebecca M},
 journal = {Review of Economics of the Household},
 number = {3},
 pages = {223--242},
-title = {{{\{}T{\}}he {\{}R{\}}esponse of {\{}H{\}}ousehold {\{}P{\}}arental {\{}I{\}}nvestment to {\{}C{\}}hild {\{}E{\}}ndowment}},
+title = {{The Response of Household Parental Investment to Child Endowment}},
 volume = {6},
 year = {2008}
 }
@@ -8208,7 +8208,7 @@ year = {2008}
 address = {Toronto, Canada},
 editor = {Louis, N Christofides E and Kenneth, Grant and Robert, Swidinsky},
 publisher = {University of Toronto Press},
-title = {{{\{}A{\}}spects of {\{}L{\}}abour {\{}M{\}}arket {\{}B{\}}ehaviour: {\{}E{\}}ssays in {\{}H{\}}onor of {\{}J{\}}ohn {\{}V{\}}anderkamp}},
+title = {{Aspects of Labour Market Behaviour: Essays in Honor of John Vanderkamp}},
 year = {1995}
 }
 @article{Loury.1981,
@@ -8216,7 +8216,7 @@ author = {Loury, Glenn C},
 journal = {Econometrica},
 number = {4},
 pages = {843--867},
-title = {{{\{}I{\}}ntergenerational {\{}T{\}}ransfers and the {\{}D{\}}istribution of {\{}E{\}}arnings}},
+title = {{Intergenerational Transfers and the Distribution of Earnings}},
 volume = {49},
 year = {1981}
 }
@@ -8249,7 +8249,7 @@ author = {Ludwig, J and Duncan, Greg J and Hirschfield, Paul},
 journal = {The Quarterly Journal of Economics},
 number = {2},
 pages = {665--679},
-title = {{{\{}U{\}}rban {\{}P{\}}overty and {\{}J{\}}uvenile {\{}C{\}}rime: {\{}E{\}}vidence from a {\{}R{\}}andomized {\{}H{\}}ousing-{\{}M{\}}obility {\{}E{\}}xperiment}},
+title = {{Urban Poverty and Juvenile Crime: Evidence from a Randomized Housing-Mobility Experiment}},
 volume = {116},
 year = {2001}
 }
@@ -8267,7 +8267,7 @@ author = {Lugo-Gil, Julieta and Tamis-LeMonda, Catherine S},
 journal = {Child Development},
 number = {4},
 pages = {1065--1085},
-title = {{{\{}F{\}}amily {\{}R{\}}esources and {\{}P{\}}arenting {\{}Q{\}}uality: {\{}L{\}}inks to {\{}C{\}}hildren's {\{}C{\}}ognitive{\$}{\~{}}{\$}{\{}D{\}}evelopment {\{}A{\}}cross the {\{}F{\}}irst 3 {\{}Y{\}}ears}},
+title = {{Family Resources and Parenting Quality: Links to Children's Cognitive Development Across the First 3 Years}},
 volume = {79},
 year = {2008}
 }
@@ -8303,10 +8303,10 @@ year = {2009}
 }
 @article{Lytle.2003,
 author = {Lytle, Leslie A and Kubik, Martha Y},
-journal = {Best Practice {\&} Research Clinical Endocrinology {\&} Metabolism},
+journal = {Best Practice \& Research Clinical Endocrinology \& Metabolism},
 number = {2},
 pages = {177--189},
-title = {{{\{}N{\}}utritional {\{}I{\}}ssues for {\{}A{\}}dolescents}},
+title = {{Nutritional Issues for Adolescents}},
 volume = {17},
 year = {2003}
 }
@@ -8322,7 +8322,7 @@ year = {2006}
 @article{Machado.2009,
 author = {Machado, C and Shaikh, Azeem and Vytlacil, Edward J},
 journal = {Working Paper},
-title = {{{\{}I{\}}nstrumental {\{}V{\}}ariables and the {\{}S{\}}ign of the {\{}A{\}}verage {\{}T{\}}reatment {\{}E{\}}ffect}},
+title = {{Instrumental Variables and the Sign of the Average Treatment Effect}},
 year = {2009}
 }
 @article{Machina.1989,
@@ -8347,12 +8347,12 @@ author = {Madansky, Albert},
 journal = {Psychometrika},
 number = {2},
 pages = {105--113},
-title = {{{\{}I{\}}nstrumental {\{}V{\}}ariables in {\{}F{\}}actor {\{}A{\}}nalysis}},
+title = {{Instrumental Variables in Factor Analysis}},
 volume = {26},
 year = {1964}
 }
 @article{Maeder.2014,
-author = {M{\"{a}}der, Miriam and M{\"{u}}ller, Steffen and Riphahn, Regina T and Schwientek, Caroline},
+author = {M\"{a}der, Miriam and M\"{u}ller, Steffen and Riphahn, Regina T and Schwientek, Caroline},
 journal = {Unpublished Manuscript},
 title = {{Intergenerational Transmission of Unemployment - Evidence from German Sons}},
 year = {2014}
@@ -8387,7 +8387,7 @@ year = {2005}
 address = {Princeton, NJ},
 author = {Manski, C},
 publisher = {Princeton University Press},
-title = {{{\{}I{\}}dentification and for {\{}P{\}}rediction and {\{}D{\}}ecision}},
+title = {{Identification and for Prediction and Decision}},
 year = {2008}
 }
 @article{Manski.1990,
@@ -8395,7 +8395,7 @@ author = {Manski, C},
 journal = {American Economic Review},
 number = {2},
 pages = {319--323},
-title = {{{\{}N{\}}onparametric {\{}B{\}}ounds on {\{}T{\}}reatment {\{}E{\}}ffects}},
+title = {{Nonparametric Bounds on Treatment Effects}},
 volume = {80},
 year = {1990}
 }
@@ -8403,14 +8403,14 @@ year = {1990}
 address = {Cambridge, MA},
 editor = {Manski, C and Garfinkel, Irwin},
 publisher = {Harvard University Press},
-title = {{{\{}E{\}}valuating {\{}W{\}}elfare and {\{}T{\}}raining {\{}P{\}}rograms}},
+title = {{Evaluating Welfare and Training Programs}},
 year = {1992}
 }
 @book{Manski.1981,
 address = {Chicago, IL},
 editor = {Manski, C and McFadden, Daniel},
-publisher = {MIT{\$}{\~{}}{\$}Press},
-title = {{{\{}S{\}}tructural {\{}A{\}}nalysis of {\{}D{\}}iscrete {\{}D{\}}ata with {\{}E{\}}conometric {\{}A{\}}pplication}},
+publisher = {MIT Press},
+title = {{Structural Analysis of Discrete Data with Econometric Application}},
 year = {1981}
 }
 @article{Manski.2000,
@@ -8418,7 +8418,7 @@ author = {Manski, C and Pepper, John V},
 journal = {Econometrica},
 number = {4},
 pages = {997--1010},
-title = {{{\{}M{\}}onotone {\{}I{\}}nstrumental {\{}V{\}}ariables: {\{}W{\}}ith an {\{}A{\}}pplication to the {\{}R{\}}eturns to {\{}S{\}}chooling}},
+title = {{Monotone Instrumental Variables: With an Application to the Returns to Schooling}},
 volume = {68},
 year = {2000}
 }
@@ -8450,7 +8450,7 @@ author = {Manski, Charles F},
 journal = {Econometrica},
 number = {4},
 pages = {1221--1246},
-title = {{{\{}S{\}}tatistical {\{}T{\}}reatment {\{}R{\}}ules for {\{}H{\}}eterogeneous {\{}P{\}}opulations}},
+title = {{Statistical Treatment Rules for Heterogeneous Populations}},
 volume = {72},
 year = {2004}
 }
@@ -8488,28 +8488,28 @@ year = {1968}
 @incollection{Marschak.1953,
 address = {New York, NY},
 author = {Marschak, Jacob},
-booktitle = {{\{}S{\}}tudies in {\{}E{\}}conometric {\{}M{\}}ethod},
+booktitle = {Studies in Econometric Method},
 editor = {Hood, W and Koopmans, T},
 pages = {1--26},
 publisher = {Wiley},
-title = {{{\{}E{\}}conometric {\{}M{\}}easurements for {\{}P{\}}olicy {\{}P{\}}redictions}},
+title = {{Econometric Measurements for Policy Predictions}},
 year = {1953}
 }
 @book{Marsh.1990,
 address = {Campelltown, New South Wales},
 author = {Marsh, H W},
-publisher = {Austrailian University of Western{\$}{\~{}}{\$}Sydney},
-title = {{{\{}S{\}}elf-{\{}D{\}}escription {\{}Q{\}}uestionnaire {\{}I{\}}}},
+publisher = {Austrailian University of Western Sydney},
+title = {{Self-Description Questionnaire I}},
 year = {1990}
 }
 @incollection{Marshak.1953,
 address = {London, UK},
 author = {Marshak, Jacob},
-booktitle = {{\{}C{\}}owles {\{}C{\}}omission for {\{}R{\}}esearch in {\{}E{\}}conomics},
+booktitle = {Cowles Comission for Research in Economics},
 editor = {{Cowles Comission}},
 pages = {1--26},
 publisher = {Wiley},
-title = {{{\{}E{\}}conomic {\{}M{\}}easurements for {\{}P{\}}olicy and {\{}P{\}}rediction}},
+title = {{Economic Measurements for Policy and Prediction}},
 year = {1953}
 }
 @article{Martinelli.2003,
@@ -8537,10 +8537,10 @@ year = {1998}
 @incollection{Matzkin.2007,
 address = {Amsterdam, NL},
 author = {Matzkin, Rosa},
-booktitle = {{\{}H{\}}andbook of {\{}E{\}}conometrics},
+booktitle = {Handbook of Econometrics},
 editor = {Heckman, James J and Leamer, Edward E},
 publisher = {Elsevier Science},
-title = {{{\{}N{\}}onparametric {\{}I{\}}dentification}},
+title = {{Nonparametric Identification}},
 year = {2007}
 }
 @article{Matzkin.1992,
@@ -8555,7 +8555,7 @@ year = {1992}
 @book{Maxfield.2003,
 author = {Maxfield, Myles and Schirm, Allen and Planas, Nuria Rodriguez},
 institution = {Mathematic Policy Research report},
-title = {{{\{}T{\}}he {\{}Q{\}}uantum {\{}O{\}}pportunity {\{}P{\}}rogram {\{}D{\}}emonstration: {\{}I{\}}mplementation and {\{}S{\}}hort {\{}T{\}}erm {\{}I{\}}mpacts}},
+title = {{The Quantum Opportunity Program Demonstration: Implementation and Short Term Impacts}},
 year = {2003}
 }
 @article{Maxwell.1877,
@@ -8570,15 +8570,15 @@ year = {1877}
 address = {Mahwah, NJ},
 author = {Maydeu-Olivares, Albert and McDonald, Roderick P},
 publisher = {Erlbaum},
-series = {{\{}M{\}}ultivariate applications series},
-title = {{{\{}C{\}}ontemporary {\{}P{\}}sychometrics: {\{}A{\}} {\{}F{\}}estschrift for {\{}R{\}}oderick {\{}P{\}}. {\{}M{\}}c{\{}D{\}}onald}},
+series = {Multivariate applications series},
+title = {{Contemporary Psychometrics: A Festschrift for Roderick P. McDonald}},
 year = {2005}
 }
 @book{Mayer.1997,
 address = {Cambridge, MA},
 author = {Mayer, Susan E},
 publisher = {Cambridge University Press},
-title = {{{\{}W{\}}hat {\{}M{\}}oney {\{}C{\}}an't {\{}B{\}}uy: {\{}F{\}}amily {\{}I{\}}ncome and {\{}C{\}}hildren's {\{}L{\}}ife {\{}C{\}}hance}},
+title = {{What Money Can't Buy: Family Income and Children's Life Chance}},
 year = {1997}
 }
 @article{Mayer.2008,
@@ -8586,7 +8586,7 @@ author = {Mayer, Susan E and Lopoo, Leonard M},
 journal = {Journal of Public Economics},
 number = {1-2},
 pages = {139--158},
-title = {{{\{}G{\}}overnment {\{}S{\}}pending and {\{}I{\}}ntergenerational {\{}M{\}}obility}},
+title = {{Government Spending and Intergenerational Mobility}},
 volume = {92},
 year = {2008}
 }
@@ -8595,7 +8595,7 @@ author = {Mazumder, Bhashkar},
 journal = {The Review of Economics and Statistics},
 number = {2},
 pages = {235--255},
-title = {{{\{}F{\}}ortunate {\{}S{\}}ons:{\$}{\~{}}{\$}{\{}N{\}}ew {\{}E{\}}stimates of {\{}I{\}}ntergenerational {\{}M{\}}obility in the {\{}U{\}}nited {\{}S{\}}tates {\{}U{\}}sing {\{}S{\}}ocial {\{}S{\}}ecurity {\{}E{\}}arnings {\{}D{\}}ata}},
+title = {{Fortunate Sons: New Estimates of Intergenerational Mobility in the United States Using Social Security Earnings Data}},
 volume = {87},
 year = {2005}
 }
@@ -8603,14 +8603,14 @@ year = {2005}
 author = {Mazumder, Bhashkar},
 journal = {Federal Reserve Bank of Chicago Working Paper},
 number = {24},
-title = {{{\{}T{\}}he {\{}M{\}}is-{\{}M{\}}easurement of {\{}P{\}}ermanent {\{}E{\}}arnings:{\$}{\~{}}{\$}{\{}N{\}}ew {\{}E{\}}vidence {\{}F{\}}rom {\{}S{\}}ocial {\{}S{\}}ecurity {\{}E{\}}arnings {\{}D{\}}ata}},
+title = {{The Mis-Measurement of Permanent Earnings: New Evidence From Social Security Earnings Data}},
 year = {2001}
 }
 @article{McClelland.2000,
 author = {McClelland, Megan M and Morrison, Frederick J and Holmes, Deborah L},
 journal = {Earl},
 pages = {307--329},
-title = {{{\{}C{\}}hildren at {\{}R{\}}isk for {\{}E{\}}arly {\{}A{\}}cademic {\{}P{\}}roblems: {\{}T{\}}he {\{}R{\}}ole of {\{}L{\}}earning-{\{}R{\}}elated {\{}S{\}}ocial {\{}S{\}}kills}},
+title = {{Children at Risk for Early Academic Problems: The Role of Learning-Related Social Skills}},
 volume = {15},
 year = {2000}
 }
@@ -8685,7 +8685,7 @@ year = {1977}
 @article{McFadden.1977,
 author = {McFadden, Daniel and Talvitie, Antti},
 journal = {Working Paper},
-title = {{{\{}D{\}}emand {\{}M{\}}odel {\{}E{\}}stimation and {\{}V{\}}alidation}},
+title = {{Demand Model Estimation and Validation}},
 year = {1977}
 }
 @incollection{McKelvey.1996,
@@ -8709,14 +8709,14 @@ year = {2010}
 address = {New York, NY},
 author = {McLachlan, Geoffrey and Peel, David},
 publisher = {Wiley},
-title = {{{\{}F{\}}inite {\{}M{\}}ixture {\{}M{\}}odels}},
+title = {{Finite Mixture Models}},
 year = {2000}
 }
 @book{McLanahan.1994,
 address = {Cambridge, MA},
 author = {McLanahan, Sara},
 publisher = {Harvard University Press},
-title = {{{\{}G{\}}rowing {\{}U{\}}p with a {\{}S{\}}ingle {\{}P{\}}arent: {\{}W{\}}hat {\{}H{\}}urts, {\{}W{\}}hat {\{}H{\}}elps?}},
+title = {{Growing Up with a Single Parent: What Hurts, What Helps?}},
 year = {1994}
 }
 @article{McLanahan.2004,
@@ -8744,7 +8744,7 @@ author = {Meaney, Michael J},
 journal = {Annual Review of Neuroscience},
 number = {1},
 pages = {1161--1192},
-title = {{{\{}M{\}}aternal {\{}C{\}}are, {\{}G{\}}ene {\{}E{\}}xpression, and the {\{}T{\}}ransmission of {\{}I{\}}ndividual {\{}D{\}}ifferences in {\{}S{\}}tress {\{}R{\}}eactivity {\{}A{\}}cross {\{}G{\}}enerations}},
+title = {{Maternal Care, Gene Expression, and the Transmission of Individual Differences in Stress Reactivity Across Generations}},
 volume = {24},
 year = {2001}
 }
@@ -8753,7 +8753,7 @@ author = {Meara, Ellen R and Richards, Seth and Cutler, David M},
 journal = {Health Affairs},
 number = {2},
 pages = {350--360},
-title = {{{\{}T{\}}he {\{}G{\}}aps {\{}G{\}}ets {\{}B{\}}igger:{\$}{\~{}}{\$}{\{}C{\}}hanges in {\{}M{\}}ortality and {\{}L{\}}ife {\{}E{\}}xpectancy, {\{}B{\}}y {\{}E{\}}ducation, 1981-200}},
+title = {{The Gaps Gets Bigger: Changes in Mortality and Life Expectancy, By Education, 1981-200}},
 volume = {27},
 year = {2008}
 }
@@ -8775,7 +8775,7 @@ year = {2008}
 @article{Meghir.2001,
 author = {Meghir, Costas and Palme, Marten},
 journal = {IFS Working Paper},
-title = {{{\{}T{\}}he {\{}E{\}}ffect of a {\{}S{\}}ocial {\{}E{\}}xperiment in {\{}E{\}}ducation}},
+title = {{The Effect of a Social Experiment in Education}},
 volume = {11},
 year = {2001}
 }
@@ -8794,14 +8794,14 @@ year = {2011}
 address = {New York, NY},
 editor = {Meisels, Samuel J and Shonkoff, Jack P},
 publisher = {Cambridge University Press},
-title = {{{\{}H{\}}andbood of {\{}E{\}}arly {\{}C{\}}hildhood {\{}I{\}}ntervention}},
+title = {{Handbood of Early Childhood Intervention}},
 year = {1990}
 }
 @article{Mela.1999,
 author = {Mela, David J},
 journal = {Proceedings of the Nutrition Society},
 pages = {513--521},
-title = {{{\{}F{\}}ood {\{}C{\}}hoice and {\{}I{\}}ntake:{\$}{\~{}}{\$}{\{}T{\}}he {\{}H{\}}uman {\{}F{\}}actor}},
+title = {{Food Choice and Intake: The Human Factor}},
 volume = {58},
 year = {1999}
 }
@@ -8869,7 +8869,7 @@ year = {1997}
 @article{Moav.2008,
 author = {Moav, Omer and Neeman, Zvika},
 journal = {Unpublished Manuscript},
-title = {{{\{}B{\}}ling {\{}B{\}}ling, {\{}H{\}}uman {\{}C{\}}apital, and {\{}P{\}}overty}},
+title = {{Bling Bling, Human Capital, and Poverty}},
 year = {2008}
 }
 @article{Mokdad.2004,
@@ -8877,14 +8877,14 @@ author = {Mokdad, Ali H and Marks, James S and Stroup, Donna F and Gerberding, J
 journal = {Journal of American Medical Association},
 number = {10},
 pages = {1238--1245},
-title = {{{\{}A{\}}ctual {\{}C{\}}auses of {\{}D{\}}eath in the {\{}U{\}}nited {\{}S{\}}tates, 2000}},
+title = {{Actual Causes of Death in the United States, 2000}},
 volume = {291},
 year = {2004}
 }
 @article{Moon.2008,
 author = {Moon, Soeng Hyoek},
 journal = {Working Paper},
-title = {{{\{}S{\}}kill - {\{}F{\}}ormation {\{}T{\}}echnology and {\{}M{\}}ulti - {\{}D{\}}imensional {\{}P{\}}arental {\{}I{\}}nvestment}},
+title = {{Skill - Formation Technology and Multi - Dimensional Parental Investment}},
 volume = {The Univer},
 year = {2008}
 }
@@ -8922,7 +8922,7 @@ author = {Morris, Pamela and Duncan, Greg J and Clark-Kauffman, Elizabeth},
 journal = {Developmental Psychology},
 number = {6},
 pages = {919--932},
-title = {{{\{}C{\}}hild {\{}W{\}}ell-{\{}B{\}}eing in an {\{}E{\}}ra of {\{}W{\}}elfare {\{}R{\}}eform:{\$}{\~{}}{\$}{\{}T{\}}he {\{}S{\}}ensitivity of {\{}T{\}}ransitions in {\{}D{\}}evelopment to {\{}P{\}}olicy {\{}C{\}}hange}},
+title = {{Child Well-Being in an Era of Welfare Reform: The Sensitivity of Transitions in Development to Policy Change}},
 volume = {41},
 year = {2005}
 }
@@ -8937,7 +8937,7 @@ author = {Muenning, Peter and Lubetkin, Erica and Jia, Haomiao and Franks, Peter
 journal = {American Journal of Public Health},
 number = {9},
 pages = {1662--1668},
-title = {{{\{}G{\}}ender and the {\{}B{\}}urden of {\{}D{\}}isease {\{}A{\}}ttributable to {\{}O{\}}besity}},
+title = {{Gender and the Burden of Disease Attributable to Obesity}},
 volume = {96},
 year = {2006}
 }
@@ -8945,14 +8945,14 @@ year = {2006}
 address = {New York, NY},
 author = {Mulaik, Stanley A},
 publisher = {McGraw-Hill},
-title = {{{\{}T{\}}he {\{}F{\}}oundations of {\{}F{\}}actor {\{}A{\}}nalysis}},
+title = {{The Foundations of Factor Analysis}},
 year = {1972}
 }
 @book{Mulligan.1997,
 address = {Chicago, IL},
 author = {Mulligan, Casey B},
 publisher = {University of Chicago Press},
-title = {{{\{}P{\}}arental {\{}P{\}}riorities and {\{}E{\}}conomic {\{}I{\}}nequality}},
+title = {{Parental Priorities and Economic Inequality}},
 year = {1997}
 }
 @techreport{TAO.2012,
@@ -8966,7 +8966,7 @@ author = {Murnane, Richard J and Willett, Johm B and Levy, Frank},
 journal = {The Review of Economics and Statistics},
 number = {2},
 pages = {251--266},
-title = {{{\{}T{\}}he {\{}G{\}}rowing {\{}I{\}}mportance of {\{}C{\}}ognitive {\{}S{\}}kills in {\{}W{\}}age {\{}D{\}}etermination}},
+title = {{The Growing Importance of Cognitive Skills in Wage Determination}},
 volume = {77},
 year = {1995}
 }
@@ -8989,7 +8989,7 @@ author = {Must, Aviva and Spadano, Jennifer and Coakley, Eugenie and Field, Alis
 journal = {Journal of the American Medical Association},
 number = {16},
 pages = {1523--1529},
-title = {{{\{}T{\}}he {\{}D{\}}isease {\{}B{\}}urden {\{}A{\}}ssociated with {\{}O{\}}verweight and {\{}O{\}}besity}},
+title = {{The Disease Burden Associated with Overweight and Obesity}},
 volume = {282},
 year = {1999}
 }
@@ -9006,14 +9006,14 @@ year = {1961}
 address = {Stanford, CA},
 editor = {Nagel, Ernest and Suppes, Patrik and Tarski, Alfred},
 publisher = {Stanford University Press},
-title = {{{\{}L{\}}ogic, {\{}M{\}}ethodology and {\{}P{\}}hilosophy of {\{}S{\}}cience}},
+title = {{Logic, Methodology and Philosophy of Science}},
 year = {1962}
 }
 @book{Najarian.2009,
 address = {Washington, D.C.},
 author = {Najarian, Michelle and Pollak, Judith M and Sorongon, Alberto G and Hausken, Elvira G},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-99 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}):{\$}{\~{}}{\$}{\{}P{\}}sychometric {\{}R{\}}eport for the {\{}E{\}}igth {\{}G{\}}rade}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-99 (ECLS-K): Psychometric Report for the Eigth Grade}},
 year = {2009}
 }
 @article{Navarro.2011,
@@ -9039,7 +9039,7 @@ author = {Neal, Derek A and Johnson, William R},
 journal = {The Journal of Political Economy},
 number = {5},
 pages = {869--895},
-title = {{{\{}T{\}}he {\{}R{\}}ole of {\{}P{\}}remarket {\{}F{\}}actors in {\{}B{\}}lack-{\{}W{\}}hite {\{}W{\}}age {\{}D{\}}ifferences}},
+title = {{The Role of Premarket Factors in Black-White Wage Differences}},
 volume = {104},
 year = {1996}
 }
@@ -9048,7 +9048,7 @@ author = {Neal, R and {Brayne C.} and Johnson, A L},
 journal = {International Journal of Epodemiology},
 number = {6},
 pages = {1383--1388},
-title = {{{\{}C{\}}ognition and {\{}S{\}}urvival: {\{}A{\}}n exploration in a {\{}L{\}}arge {\{}M{\}}ulticentre {\{}S{\}}tudy}},
+title = {{Cognition and Survival: An exploration in a Large Multicentre Study}},
 volume = {30},
 year = {2001}
 }
@@ -9056,14 +9056,14 @@ year = {2001}
 author = {Neidell, Matthew and Waldfogel, Jane},
 journal = {Review of Economics and Statistics},
 pages = {forthcoming},
-title = {{{\{}C{\}}ognitive and {\{}N{\}}oncognitive {\{}P{\}}eer {\{}E{\}}ffects in {\{}E{\}}arly {\{}E{\}}ducation}},
+title = {{Cognitive and Noncognitive Peer Effects in Early Education}},
 year = {2010}
 }
 @book{Nelsen.2007,
 address = {New York, NY},
 author = {Nelsen, Roger B},
 publisher = {Springer},
-title = {{{\{}A{\}}n {\{}I{\}}ntroduction to {\{}C{\}}opulas}},
+title = {{An Introduction to Copulas}},
 year = {2007}
 }
 @article{Nevo2010,
@@ -9082,7 +9082,7 @@ year = {2010}
 author = {Newcomba, Andrew F and Bukowskib, William M and Patteea, Linda},
 journal = {Psychological Bulletin},
 pages = {99--128},
-title = {{{\{}C{\}}hildren's {\{}P{\}}eer {\{}R{\}}elations: {\{}A {\}}{\{}M{\}}eta-{\{}A{\}}nalytic {\{}R{\}}eview of {\{}P{\}}opular, {\{}R{\}}ejected, {\{}N{\}}eglected, {\{}C{\}}ontroversial, and {\{}A{\}}verage {\{}S{\}}ociometric {\{}S{\}}tatus}},
+title = {{Children's Peer Relations: {\{}A {\}}Meta-Analytic Review of Popular, Rejected, Neglected, Controversial, and Average Sociometric Status}},
 volume = {113},
 year = {1993}
 }
@@ -9091,7 +9091,7 @@ author = {Newport, Elissa L},
 journal = {Cognitive Science},
 number = {1},
 pages = {11--28},
-title = {{{\{}M{\}}aturational {\{}C{\}}onstraints on {\{}L{\}}anguage {\{}L{\}}earning}},
+title = {{Maturational Constraints on Language Learning}},
 volume = {14},
 year = {1990}
 }
@@ -9100,7 +9100,7 @@ author = {{NICHD Early Child Care Research Network}},
 journal = {Child Development},
 number = {4},
 pages = {960--980},
-title = {{{\{}T{\}}he {\{}R{\}}elation of {\{}C{\}}hild {\{}C{\}}are to {\{}C{\}}ognitive and {\{}L{\}}anguage {\{}D{\}}evelopment}},
+title = {{The Relation of Child Care to Cognitive and Language Development}},
 volume = {71},
 year = {2000}
 }
@@ -9109,7 +9109,7 @@ author = {{NICHD Early Child Care Research Network}},
 journal = {American Journal of Public Health},
 number = {7},
 pages = {1072--1077},
-title = {{{\{}C{\}}hild {\{}O{\}}utcomes {\{}W{\}}hen {\{}C{\}}hild {\{}C{\}}are {\{}C{\}}enter {\{}C{\}}lasses {\{}M{\}}eet {\{}R{\}}ecommended {\{}S{\}}tandards for {\{}Q{\}}uality}},
+title = {{Child Outcomes When Child Care Center Classes Meet Recommended Standards for Quality}},
 volume = {89},
 year = {1999}
 }
@@ -9118,7 +9118,7 @@ author = {NICHD and Duncan, Greg J},
 journal = {Child Development},
 number = {5},
 pages = {1454--1475},
-title = {{{\{}M{\}}odeling the {\{}I{\}}mpacts of {\{}C{\}}hild {\{}C{\}}are {\{}Q{\}}uality on {\{}C{\}}hildren's {\{}P{\}}reschool {\{}C{\}}ognitive {\{}D{\}}evelopment}},
+title = {{Modeling the Impacts of Child Care Quality on Children's Preschool Cognitive Development}},
 volume = {74},
 year = {2003}
 }
@@ -9135,7 +9135,7 @@ year = {2005}
 address = {Cambridge, MA},
 author = {Nilim, Arnab and Ghaoui, Laurent El},
 booktitle = {Advances in Neural Information Processing Systems 16},
-editor = {Thrun, S and Saul, L K and Sch{\"{o}}lkopf, B},
+editor = {Thrun, S and Saul, L K and Sch\"{o}lkopf, B},
 pages = {839--846},
 publisher = {MIT Press},
 title = {{Robustness in Markov Decision Problems with Uncertain Transition Matrices}},
@@ -9220,7 +9220,7 @@ author = {O'Connor, Thomas G and Rutter, Michael and Beckett, Celia and Keaveney
 journal = {Child Development},
 number = {2},
 pages = {376--390},
-title = {{{\{}T{\}}he {\{}E{\}}ffects of {\{}G{\}}lobal {\{}S{\}}evere {\{}P{\}}rivation on {\{}C{\}}ognitive {\{}C{\}}ompetence: {\{}E{\}}xtension and {\{}L{\}}ongitudinal {\{}F{\}}ollow-{\{}U{\}}p}},
+title = {{The Effects of Global Severe Privation on Cognitive Competence: Extension and Longitudinal Follow-Up}},
 volume = {71},
 year = {2000}
 }
@@ -9228,7 +9228,7 @@ year = {2000}
 address = {Paris, France},
 author = {OECD},
 publisher = {OECD Publication Service},
-title = {{{\{}O{\}}{\{}E{\}}{\{}C{\}}{\{}D{\}} {\{}E{\}}mployment {\{}O{\}}utlook}},
+title = {{OECD Employment Outlook}},
 year = {1999}
 }
 @book{OECD.1998,
@@ -9273,7 +9273,7 @@ author = {Ogden, Cynthia L and Carroll, Margaret D and Curtin, Lester R and McDo
 journal = {Journal of American Medical Association},
 number = {13},
 pages = {1549--1555},
-title = {{{\{}P{\}}revalence of {\{}O{\}}verweight and {\{}O{\}}besity in the {\{}U{\}}nited {\{}S{\}}tates, 1999 - 2004}},
+title = {{Prevalence of Overweight and Obesity in the United States, 1999 - 2004}},
 volume = {295},
 year = {2006}
 }
@@ -9282,7 +9282,7 @@ author = {Olds, David L},
 journal = {Prevention Science},
 number = {2},
 pages = {153--172},
-title = {{{\{}P{\}}renatal and {\{}I{\}}nfancy {\{}H{\}}ome {\{}V{\}}isiting by {\{}N{\}}urses: {\{}F{\}}rom {\{}R{\}}andomized {\{}T{\}}rials to {\{}C{\}}ommunity {\{}R{\}}eplication}},
+title = {{Prenatal and Infancy Home Visiting by Nurses: From Randomized Trials to Community Replication}},
 volume = {3},
 year = {2002}
 }
@@ -9297,7 +9297,7 @@ year = {2005}
 }
 @article{Oliphant.2007,
 author = {Oliphant, Travis E},
-journal = {Computing in Science {\&} Engineering},
+journal = {Computing in Science \& Engineering},
 number = {90},
 pages = {10--20},
 title = {{Python for Scientific Computing}},
@@ -9323,7 +9323,7 @@ volume = {1},
 year = {2003}
 }
 @article{Oncan.2007,
-author = {{\"{O}}ncan, Temel},
+author = {\"{O}ncan, Temel},
 journal = {INFOR: Information Systems and Operational Research},
 number = {3},
 pages = {123--141},
@@ -9335,7 +9335,7 @@ year = {2007}
 author = {Orcutt, Guy H and Orcutt, Alice G},
 journal = {American Economic Review},
 pages = {754--772},
-title = {{{\{}I{\}}ncentive and {\{}D{\}}isincentive {\{}E{\}}xperimentation for {\{}I{\}}ncome {\{}M{\}}aintenance {\{}P{\}}olicy {\{}P{\}}urposes}},
+title = {{Incentive and Disincentive Experimentation for Income Maintenance Policy Purposes}},
 volume = {58},
 year = {1968}
 }
@@ -9351,11 +9351,11 @@ year = {2008}
 @incollection{Groves.2005,
 address = {Princeton, NJ},
 author = {Osborne-Groves, Melissa},
-booktitle = {{\{}U{\}}nequal {\{}C{\}}hances: {\{}F{\}}amily {\{}B{\}}ackground and {\{}E{\}}conomic {\{}S{\}}uccess},
+booktitle = {Unequal Chances: Family Background and Economic Success},
 editor = {Bowles, Samuel and Gintis, Herbert and Osborne-Groves, Melissa},
 pages = {49--81},
 publisher = {Princeton University Press},
-title = {{{\{}P{\}}ersonality and the {\{}I{\}}ntergenerational {\{}T{\}}ransmission of {\{}E{\}}conomic {\{}S{\}}tatus}},
+title = {{Personality and the Intergenerational Transmission of Economic Status}},
 volume = {2},
 year = {2005}
 }
@@ -9381,14 +9381,14 @@ year = {1989}
 author = {Palaca, Joseph},
 journal = {Science Magazine},
 pages = {19--21},
-title = {{{\{}A{\}}{\{}I{\}}{\{}D{\}}{\{}S{\}}{\$}{\~{}}{\$}{\{}D{\}}rug {\{}T{\}}rails {\{}E{\}}nter {\{}N{\}}ew {\{}A{\}}ge}},
+title = {{AIDS Drug Trails Enter New Age}},
 year = {1989}
 }
 @article{Parker.1987,
 author = {Parker, Jeffrey G and Asher, Steven R},
 journal = {Psychological Bulletin},
 pages = {357--389},
-title = {{{\{}P{\}}eer {\{}R{\}}elations and {\{}L{\}}ater {\{}P{\}}ersonal {\{}A{\}}djustment: {\{}A{\}}re {\{}L{\}}ow-{\{}A{\}}ccepted {\{}C{\}}hildren at {\{}R{\}}isk?}},
+title = {{Peer Relations and Later Personal Adjustment: Are Low-Accepted Children at Risk?}},
 volume = {102},
 year = {1987}
 }
@@ -9413,7 +9413,7 @@ author = {Peisner-Feinberg, Ellen S and Burchinal, Margaret R and Clifford, Rich
 journal = {Child Development},
 number = {5},
 pages = {1534--1553},
-title = {{{\{}T{\}}he {\{}R{\}}elation of {\{}P{\}}reschool {\{}C{\}}hild-{\{}C{\}}are {\{}Q{\}}uality to {\{}C{\}}hildren's {\{}C{\}}ognitive and {\{}S{\}}ocial {\{}D{\}}evelopmental {\{}T{\}}rajectories through {\{}S{\}}econd {\{}G{\}}rade}},
+title = {{The Relation of Preschool Child-Care Quality to Children's Cognitive and Social Developmental Trajectories through Second Grade}},
 volume = {72},
 year = {2001}
 }
@@ -9433,7 +9433,7 @@ year = {2001}
 @article{Peragine.2007,
 author = {Peragine, Vito and Serlenga, Laura},
 journal = {IZA Discussion Paper},
-title = {{{\{}H{\}}igher {\{}E{\}}ducation and {\{}E{\}}quality of {\{}O{\}}pportunity in {\{}I{\}}taly}},
+title = {{Higher Education and Equality of Opportunity in Italy}},
 volume = {No. 3163},
 year = {2007}
 }
@@ -9442,15 +9442,15 @@ author = {Perri, Timothy J},
 journal = {Economic of Education Review},
 number = {3},
 pages = {207--213},
-title = {{{\{}H{\}}ealth {\{}S{\}}tatus and {\{}S{\}}chooling {\{}D{\}}ecisions of {\{}Y{\}}oung {\{}M{\}}en}},
+title = {{Health Status and Schooling Decisions of Young Men}},
 volume = {3},
 year = {1984}
 }
 @article{Perry.1996,
 author = {Perry, Nancy E and Meisels, Samuel J},
-journal = {NCES{\$}{\~{}}{\$}Working Papers},
+journal = {NCES Working Papers},
 number = {96-08},
-title = {{{\{}H{\}}ow {\{}A{\}}ccurate are {\{}T{\}}eachers {\{}J{\}}udgments of{\$}{\~{}}{\$}{\{}S{\}}tudents' {\{}A{\}}cademic {\{}P{\}}erformance}},
+title = {{How Accurate are Teachers Judgments of Students' Academic Performance}},
 year = {1996}
 }
 @incollection{Pesaran.2008,
@@ -9498,14 +9498,14 @@ year = {2009}
 author = {Petrides, K V and Chamorro-Premuzic, Tomas and Frederickson, Norah and Furnham, Adrian},
 journal = {Journal of Education Psychology},
 pages = {239--255},
-title = {{{\{}E{\}}xplaining {\{}I{\}}ndividual {\{}D{\}}ifferences in {\{}S{\}}cholastic {\{}B{\}}ehavior and {\{}A{\}}chievement}},
+title = {{Explaining Individual Differences in Scholastic Behavior and Achievement}},
 volume = {75},
 year = {2005}
 }
 @article{Pfeiffer.2008,
 author = {Pfeiffer, Friedhelm and Reu{\ss}, Karsten},
 journal = {Labour Economics},
-title = {{{\{}A{\}}ge-dependent {\{}S{\}}kill {\{}F{\}}ormation and {\{}R{\}}eturns to {\{}E{\}}ducation}},
+title = {{Age-dependent Skill Formation and Returns to Education}},
 volume = {forthcomin},
 year = {2008}
 }
@@ -9513,20 +9513,20 @@ year = {2008}
 author = {Pianta, Robert C and Stuhlman, Megan W},
 journal = {Psychological Bulletin},
 pages = {444--458},
-title = {{{\{}T{\}}eacher-{\{}C{\}}hild {\{}R{\}}elationships and {\{}C{\}}hildren's {\{}S{\}}uccess in the {\{}F{\}}irst {\{}Y{\}}ears of {\{}S{\}}chool}},
+title = {{Teacher-Child Relationships and Children's Success in the First Years of School}},
 volume = {33},
 year = {2004}
 }
 @article{Piatek.2009,
 author = {Piatek, R{\`{e}}mi},
 journal = {Unpublished Technical Report},
-title = {{{\{}B{\}}ayesian {\{}I{\}}nference for {\{}F{\}}actor {\{}S{\}}tructure {\{}M{\}}odels via {\{}G{\}}ibbs {\{}S{\}}ampling}},
+title = {{Bayesian Inference for Factor Structure Models via Gibbs Sampling}},
 year = {2010}
 }
 @article{Piatek.2010,
 author = {Piatek, Remi and Pinger, Pia},
 journal = {Working Paper},
-title = {{Maintaining ({\{}L{\}}ocus of) {\{}C{\}}ontrol? {\{}A{\}}ssessing the {\{}I{\}}mpact of {\{}L{\}}ocus of {\{}C{\}}ontrol on {\{}E{\}}ducation {\{}D{\}}ecisions and {\{}W{\}}ages}},
+title = {{Maintaining (Locus of) Control? Assessing the Impact of Locus of Control on Education Decisions and Wages}},
 year = {2010}
 }
 @article{Piatek.2010b,
@@ -9539,11 +9539,11 @@ year = {2010}
 @incollection{Piketty.2000,
 address = {Amsterdam, NL},
 author = {Piketty, Thomas},
-booktitle = {{\{}H{\}}anbook of {\{}I{\}}ncome {\{}D{\}}istribution},
+booktitle = {Hanbook of Income Distribution},
 editor = {Atkinson, Anthony B and Bourguignon, Francois},
 pages = {429--476},
 publisher = {Elsevier Science},
-title = {{{\{}T{\}}heories of {\{}P{\}}ersistent {\{}I{\}}nequality and {\{}I{\}}ntergenerational {\{}M{\}}obility}},
+title = {{Theories of Persistent Inequality and Intergenerational Mobility}},
 year = {2000}
 }
 @article{Pindyck.2013,
@@ -9559,14 +9559,14 @@ year = {2013}
 address = {New York, NY},
 author = {Pinker, Steven},
 publisher = {Viking-Penguin},
-title = {{{\{}T{\}}he {\{}B{\}}lank {\{}S{\}}late:{\$}{\~{}}{\$}{\{}T{\}}he {\{}M{\}}odern {\{}D{\}}enial of {\{}H{\}}uman {\{}N{\}}ature}},
+title = {{The Blank Slate: The Modern Denial of Human Nature}},
 year = {2002}
 }
 @book{Pinker.1994b,
 address = {New York, NY},
 author = {Pinker, Steven},
 publisher = {W. Morrow and Co.},
-title = {{{\{}T{\}}he {\{}L{\}}anguage {\{}I{\}}nstinct:{\$}{\~{}}{\$}{\{}H{\}}ow the {\{}M{\}}ind {\{}C{\}}reates {\{}L{\}}anguage}},
+title = {{The Language Instinct: How the Mind Creates Language}},
 year = {1994}
 }
 @article{Pistaferri.2001,
@@ -9579,17 +9579,17 @@ volume = {83},
 year = {2001}
 }
 @book{Plomin.1994,
-address = {Thousand Oaks,{\$}{\~{}}{\$}CA},
+address = {Thousand Oaks, CA},
 author = {Plomin, Robert},
 publisher = {Sage Publications},
-title = {{{\{}G{\}}enetics and {\{}E{\}}xperience:{\$}{\~{}}{\$}{\{}T{\}}he {\{}I{\}}nterplay between nature and nurture}},
+title = {{Genetics and Experience: The Interplay between nature and nurture}},
 year = {1994}
 }
 @book{Plomin.2001,
 address = {New York, NY},
 author = {Plomin, Robert and DeFries, John C and McClearn, Gerald E and McGuffin, Peter},
 publisher = {Worth},
-title = {{{\{}B{\}}ehavioral {\{}G{\}}enetics}},
+title = {{Behavioral Genetics}},
 year = {2001}
 }
 @article{Pohl.2016,
@@ -9601,7 +9601,7 @@ year = {2016}
 @article{Pohlmeier.2009,
 author = {Pohlmeier, Winfried and Wichert, Laura},
 journal = {Working Paper},
-title = {{{\{}F{\}}emale {\{}L{\}}abor {\{}F{\}}orce {\{}P{\}}articipation and the {\{}B{\}}ig {\{}F{\}}ive}},
+title = {{Female Labor Force Participation and the Big Five}},
 volume = {University},
 year = {2009}
 }
@@ -9609,29 +9609,29 @@ year = {2009}
 address = {Washington, D.C.},
 author = {Pollack and Atkins-Burnett and Najarian and Rock},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-99 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}P{\}}sychometric {\{}R{\}}eport for the {\{}F{\}}ifth {\{}G{\}}rade}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-99 (ECLS-K): Psychometric Report for the Fifth Grade}},
 year = {2005}
 }
 @book{Pollak.2005b,
 address = {Washington, D.C.},
 author = {Pollak, Judith M and Atkins-Burnett and Rock and Weiss},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-99 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}P{\}}sychometric {\{}R{\}}eport for the {\{}T{\}}hird {\{}G{\}}rade}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-99 (ECLS-K): Psychometric Report for the Third Grade}},
 year = {2005}
 }
 @book{Pollak.2005,
 address = {Washington, D.C},
 author = {Pollak, Judith M and Najarian, Michelle and Rock, Donald A and Atkins-Brunett, Sally},
-institution = {U.S.{\$}{\~{}}{\$}Department of Education},
+institution = {U.S. Department of Education},
 publisher = {National Center for Education Statistics},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten{\$}{\~{}}{\$}{\{}C{\}}lass of 1998-1999 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}), {\{}P{\}}sychometric {\{}R{\}}eport for the {\{}F{\}}ifth {\{}G{\}}rade}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-1999 (ECLS-K), Psychometric Report for the Fifth Grade}},
 year = {2005}
 }
 @book{Pollak.2002,
 address = {Washington, D.C.},
 author = {Pollak, Judith M and Rock, Donald A},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-99 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}P{\}}sychometric {\{}R{\}}eport for {\{}K{\}}indergarten {\{}T{\}}hrough {\{}F{\}}irst {\{}G{\}}rade}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-99 (ECLS-K): Psychometric Report for Kindergarten Through First Grade}},
 year = {2002}
 }
 @techreport{Pop-Eleches.2011,
@@ -9682,7 +9682,7 @@ author = {Pray, Leslie A},
 journal = {The Scientist},
 number = {13},
 pages = {14--20},
-title = {{{\{}E{\}}pigenetics:{\$}{\~{}}{\$}{\{}G{\}}enome, {\{}M{\}}eet your {\{}E{\}}nvironment}},
+title = {{Epigenetics: Genome, Meet your Environment}},
 volume = {18},
 year = {2004}
 }
@@ -9699,7 +9699,7 @@ year = {2008}
 author = {Prieger, James E},
 journal = {Journal of Applied Econometrics},
 pages = {367--392},
-title = {{{\{}A{\}} {\{}F{\}}lexible {\{}P{\}}arametric {\{}S{\}}election {\{}M{\}}odel for {\{}N{\}}on-{\{}N{\}}ormal {\{}D{\}}ata with {\{}A{\}}pplication to {\{}H{\}}ealth {\{}C{\}}are {\{}U{\}}sage}},
+title = {{A Flexible Parametric Selection Model for Non-Normal Data with Application to Health Care Usage}},
 volume = {17},
 year = {2002}
 }
@@ -9708,14 +9708,14 @@ author = {Pries, Michael and Rogerson, Richard},
 journal = {Journal of Political Economy},
 number = {4},
 pages = {811--839},
-title = {{{\{}H{\}}iring {\{}P{\}}olicies, {\{}L{\}}abor {\{}M{\}}arket {\{}I{\}}nstitutions and {\{}L{\}}abor {\{}M{\}}arket {\{}F{\}}lows}},
+title = {{Hiring Policies, Labor Market Institutions and Labor Market Flows}},
 volume = {113},
 year = {2005}
 }
 @article{Primiceri.2007,
 author = {Primiceri, Giorgio E and van Rens, Thijs},
 journal = {IZA Discussion Paper},
-title = {{{\{}H{\}}eterogeneous {\{}L{\}}ife-{\{}C{\}}ycle {\{}P{\}}rofiles, {\{}I{\}}ncome {\{}R{\}}isk and {\{}C{\}}onsumption {\{}I{\}}nequality}},
+title = {{Heterogeneous Life-Cycle Profiles, Income Risk and Consumption Inequality}},
 volume = {No. 3239},
 year = {2007}
 }
@@ -9724,7 +9724,7 @@ author = {Pudney, Stephen},
 journal = {Journal of the American Statistical Association},
 number = {380},
 pages = {883--889},
-title = {{{\{}E{\}}stimating {\{}L{\}}atent {\{}V{\}}ariable {\{}S{\}}ystems {\{}W{\}}hen {\{}S{\}}pecification is {\{}U{\}}ncertain: {\{}G{\}}eneralized {\{}C{\}}omponent {\{}A{\}}nalysis and the {\{}E{\}}liminant {\{}M{\}}ethod}},
+title = {{Estimating Latent Variable Systems When Specification is Uncertain: Generalized Component Analysis and the Eliminant Method}},
 volume = {77},
 year = {1982}
 }
@@ -9746,7 +9746,7 @@ author = {Quandt, Richard E},
 journal = {Journal of the American Statistical Association},
 number = {284},
 pages = {873--880},
-title = {{{\{}T{\}}he {\{}E{\}}stimation of the {\{}P{\}}arameters of a {\{}L{\}}inear {\{}R{\}}egression {\{}S{\}}ystem {\{}O{\}}beying two {\{}S{\}}eparate {\{}R{\}}egimes}},
+title = {{The Estimation of the Parameters of a Linear Regression System Obeying two Separate Regimes}},
 volume = {53},
 year = {1958}
 }
@@ -9755,7 +9755,7 @@ author = {Quandt, Richard E},
 journal = {Journal of the American Statistical Association},
 number = {338},
 pages = {306--310},
-title = {{{\{}A{\}} {\{}N{\}}ew {\{}A{\}}pproach to {\{}E{\}}stimating {\{}S{\}}witching {\{}R{\}}egressions}},
+title = {{A New Approach to Estimating Switching Regressions}},
 url = {306-310},
 volume = {67},
 year = {1972}
@@ -9763,7 +9763,7 @@ year = {1972}
 @article{Raach.2005,
 author = {Raach, Alexander},
 journal = {Working Paper},
-title = {{{\{}A{\}}{\$}{\~{}}{\$}{\{}B{\}}ayesian {\{}S{\}}emiparametric {\{}L{\}}atent {\{}V{\}}ariable {\{}M{\}}odel for {\{}B{\}}inary, {\{}O{\}}rdinal and {\{}C{\}}ontinuous {\{}R{\}}esponse}},
+title = {{A Bayesian Semiparametric Latent Variable Model for Binary, Ordinal and Continuous Response}},
 volume = {University},
 year = {2005}
 }
@@ -9772,14 +9772,14 @@ author = {Raad, Boele and Schouwenburg, Henri C},
 journal = {European Journal of Personality},
 number = {5},
 pages = {303--336},
-title = {{{\{}P{\}}ersonality in {\{}L{\}}earning and {\{}E{\}}ducation: {\{}A{\}} {\{}R{\}}eview}},
+title = {{Personality in Learning and Education: A Review}},
 volume = {10},
 year = {1996}
 }
 @article{Radebusch.2004,
 author = {Radebusch, Stephen W},
 journal = {9th Angoff Memorial Lecture},
-title = {{{\{}S{\}}chooling, {\{}S{\}}tatistics and {\{}P{\}}overty: {\{}M{\}}easuring {\{}S{\}}chool {\{}I{\}}mprovement and {\{}I{\}}mproving {\{}S{\}}chools}},
+title = {{Schooling, Statistics and Poverty: Measuring School Improvement and Improving Schools}},
 year = {2004}
 }
 @incollection{Ramsey.1931,
@@ -9795,23 +9795,23 @@ year = {1931}
 address = {Copenhagen, Denmark},
 author = {Rasch, Georg},
 publisher = {Nielsen and Lydiche},
-title = {{{\{}P{\}}robabilistic {\{}M{\}}odels for {\{}S{\}}ome {\{}I{\}}ntelligence and {\{}A{\}}ttainment {\{}T{\}}ests}},
+title = {{Probabilistic Models for Some Intelligence and Attainment Tests}},
 year = {1960}
 }
 @incollection{Raver.2007,
 address = {Baltimore, MD},
 author = {Raver, Cybele C and Garner, Pamela W and Smith-Donald, Radiah},
-booktitle = {{\{}S{\}}chool {\{}R{\}}eadiness and the{\$}{\~{}}{\$}{\{}T{\}}ransition to {\{}K{\}}indergarten in the {\{}E{\}}ra of {\{}A{\}}ccountability},
+booktitle = {School Readiness and the Transition to Kindergarten in the Era of Accountability},
 editor = {Pianta, Robert C and Cox, Martha J and Snow, Kyle L},
 publisher = {Brookes Publishing},
-title = {{{\{}T{\}}he {\{}R{\}}oles of {\{}E{\}}motion {\{}R{\}}egulation and {\{}E{\}}motion {\{}K{\}}nowledge for {\{}C{\}}hildren's {\{}A{\}}cademic {\{}R{\}}eadiness:{\$}{\~{}}{\$}{\{}A{\}}re the {\{}L{\}}inks {\{}C{\}}asual?}},
+title = {{The Roles of Emotion Regulation and Emotion Knowledge for Children's Academic Readiness: Are the Links Casual?}},
 year = {2007}
 }
 @article{Raver.1997,
 author = {Raver, Cybele C and Zigler, Edward F},
 journal = {Early Childhood Research Quarterly},
 pages = {363--385},
-title = {{{\{}S{\}}ocial {\{}C{\}}ompetence: {\{}A{\}}n {\{}U{\}}ntapped {\{}D{\}}imension in {\{}E{\}}valuating {\{}H{\}}ead {\{}S{\}}tart's {\{}S{\}}uccess}},
+title = {{Social Competence: An Untapped Dimension in Evaluating Head Start's Success}},
 volume = {12},
 year = {1997}
 }
@@ -9847,7 +9847,7 @@ year = {2010}
 address = {Cambridge, MA},
 author = {Reiss, David and Niederheise, Janea M and Hetherington, Mavis E and Plomin, Robert},
 publisher = {Harvard University Press},
-title = {{{\{}T{\}}he {\{}R{\}}elationship {\{}C{\}}ode}},
+title = {{The Relationship Code}},
 year = {2000}
 }
 @misc{respy-1.0,
@@ -9862,14 +9862,14 @@ author = {Reynolds, Arthur J and Robertson, Dylan and Temple, Judy A and Mann, E
 journal = {Journal of American Medical Association},
 number = {18},
 pages = {2339--2346},
-title = {{{\{}L{\}}ong-{\{}T{\}}erm {\{}E{\}}ffects of an {\{}E{\}}arly {\{}C{\}}hildhood {\{}I{\}}ntervention on {\{}E{\}}ducational {\{}A{\}}chievement and {\{}J{\}}uvenile {\{}A{\}}rrest: {\{}A{\}} 15-{\{}Y{\}}ear {\{}F{\}}ollow-{\{}U{\}}p of {\{}L{\}}ow-{\{}I{\}}ncome {\{}C{\}}hildren in {\{}P{\}}ublic {\{}S{\}}chools}},
+title = {{Long-Term Effects of an Early Childhood Intervention on Educational Achievement and Juvenile Arrest: A 15-Year Follow-Up of Low-Income Children in Public Schools}},
 volume = {285},
 year = {2001}
 }
 @incollection{Reynolds.2006,
 address = {Cambridge, MA},
 author = {Reynolds, Arthur J and Temple, Judy A},
-booktitle = {{\{}A{\}} {\{}V{\}}ision for {\{}U{\}}niversal {\{}P{\}}reschool {\{}E{\}}ducation},
+booktitle = {A Vision for Universal Preschool Education},
 editor = {Zigler, Edward F and Gilliam, Walter S and Jones, Stephanie M},
 pages = {37--68},
 publisher = {Cambridge University Press},
@@ -9905,7 +9905,7 @@ author = {Richardson, Sylvia and Green, Peter J},
 journal = {Journal of the Royal Statistical Society B},
 number = {4},
 pages = {731--792},
-title = {{{\{}O{\}}n {\{}B{\}}ayesian {\{}A{\}}nalysis of {\{}M{\}}ixtures with an {\{}U{\}}nknown {\{}N{\}}umber of {\{}C{\}}omponents}},
+title = {{On Bayesian Analysis of Mixtures with an Unknown Number of Components}},
 volume = {59},
 year = {1997}
 }
@@ -9913,7 +9913,7 @@ year = {1997}
 author = {Richardson, Sylvia and Leblond, Laurent and Jaussent, Isabelle and Green, Peter J},
 journal = {Journal of the Royal Statistical Society B},
 number = {549-566},
-title = {{{\{}M{\}}ixture {\{}M{\}}odels in {\{}M{\}}easurement {\{}E{\}}rror {\{}P{\}}roblems, with {\{}R{\}}eference to {\{}E{\}}pidemiological {\{}S{\}}tudies}},
+title = {{Mixture Models in Measurement Error Problems, with Reference to Epidemiological Studies}},
 volume = {165},
 year = {2002}
 }
@@ -9921,7 +9921,7 @@ year = {2002}
 address = {Cambridge, MA},
 author = {Ridley, Matt},
 publisher = {Harvard University Press},
-title = {{{\{}N{\}}ature {\{}V{\}}ia {\{}N{\}}urture: {\{}G{\}}enes. {\{}G{\}}enes, {\{}E{\}}xperience, and {\{}W{\}}hat {\{}M{\}}akes us {\{}H{\}}uman}},
+title = {{Nature Via Nurture: Genes. Genes, Experience, and What Makes us Human}},
 year = {2003}
 }
 @article{Rimm-Kaufman.2000,
@@ -9963,7 +9963,7 @@ author = {Rivers, Douglas and Vuong, Quang},
 journal = {Journal of Econometrics},
 number = {3},
 pages = {347--366},
-title = {{{\{}L{\}}imited {\{}I{\}}nformation {\{}E{\}}stimators and {\{}E{\}}xogeneity {\{}T{\}}ests for {\{}S{\}}imultaneous {\{}P{\}}robit {\{}M{\}}odels}},
+title = {{Limited Information Estimators and Exogeneity Tests for Simultaneous Probit Models}},
 volume = {39},
 year = {1988}
 }
@@ -9971,7 +9971,7 @@ year = {1988}
 author = {Robert, Christian P},
 journal = {Statistics and Computing},
 pages = {121--125},
-title = {{{\{}S{\}}imulation of {\{}T{\}}runcated {\{}N{\}}ormal {\{}V{\}}ariables}},
+title = {{Simulation of Truncated Normal Variables}},
 volume = {5},
 year = {1995}
 }
@@ -9984,10 +9984,10 @@ year = {2004}
 }
 @article{Robert.1999,
 author = {Robert, Christian P and Mengersen, Kerrie L},
-journal = {Computational Statistics {\&}{\$}{\~{}}{\$}Data Analysis},
+journal = {Computational Statistics \& Data Analysis},
 number = {3},
 pages = {325--343},
-title = {{{\{}R{\}}eparametrization {\{}I{\}}ssues in {\{}M{\}}ixture {\{}M{\}}odelling and {\{}T{\}}heir {\{}B{\}}earing on {\{}M{\}}{\{}C{\}}{\{}M{\}}{\{}C{\}}{\$}{\~{}}{\$}{\{}A{\}}lgorithms}},
+title = {{Reparametrization Issues in Mixture Modelling and Their Bearing on MCMC Algorithms}},
 volume = {29},
 year = {1999}
 }
@@ -9996,7 +9996,7 @@ author = {Roberts, Brent W and Kuneel, Nathan R and Shiner, Rebecca and Caspi, A
 journal = {Perspective on Psychological Science},
 number = {4},
 pages = {313--345},
-title = {{{\{}T{\}}he {\{}P{\}}ower of {\{}P{\}}ersonality: {\{}T{\}}he {\{}C{\}}omparative {\{}V{\}}alidity of {\{}P{\}}ersonality {\{}T{\}}raits, {\{}S{\}}ocioeconomic {\{}S{\}}tatus, and {\{}C{\}}ognitive {\{}A{\}}bility for {\{}P{\}}redicting {\{}I{\}}mportant {\{}L{\}}ife {\{}O{\}}utcomes}},
+title = {{The Power of Personality: The Comparative Validity of Personality Traits, Socioeconomic Status, and Cognitive Ability for Predicting Important Life Outcomes}},
 volume = {2},
 year = {2007}
 }
@@ -10016,7 +10016,7 @@ author = {Robinson, P M},
 journal = {Econometrica},
 number = {4},
 pages = {931--954},
-title = {{{\{}R{\}}oot-{\{}N{\}}-{\{}C{\}}onsistent {\{}S{\}}emiparametric {\{}R{\}}egression}},
+title = {{Root-N-Consistent Semiparametric Regression}},
 volume = {56},
 year = {1988}
 }
@@ -10031,14 +10031,14 @@ year = {1970}
 address = {Cambridge, MA},
 author = {Roemer, John E},
 publisher = {Harvard University Press},
-title = {{{\{}E{\}}quality of {\{}O{\}}pportunity}},
+title = {{Equality of Opportunity}},
 year = {1998}
 }
 @book{Rolnick.2003,
 address = {Minneapolis, MN},
 author = {Rolnick, Art and Grunewald, Rob},
 publisher = {Federal Reserve Bank of Minneapolis},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}D{\}}evelopment: {\{}E{\}}conomic {\{}D{\}}evelopment with a {\{}H{\}}igh {\{}P{\}}ublic {\{}R{\}}eturn}},
+title = {{Early Childhood Development: Economic Development with a High Public Return}},
 year = {2003}
 }
 @article{Romano.2006,
@@ -10046,7 +10046,7 @@ author = {Romano, Joseph P and Shaikh, Azeem},
 journal = {The Annals of Statistics},
 number = {4},
 pages = {1850--1873},
-title = {{{\{}S{\}}tepup {\{}P{\}}rocedures for {\{}C{\}}ontrol of {\{}G{\}}eneralizations of the {\{}F{\}}amilywise {\{}E{\}}rror {\{}R{\}}ate}},
+title = {{Stepup Procedures for Control of Generalizations of the Familywise Error Rate}},
 volume = {34},
 year = {2006}
 }
@@ -10055,7 +10055,7 @@ author = {Romano, Joseph P and Wolf, Michael},
 journal = {Journal of the American Statistical Association},
 number = {469},
 pages = {94--108},
-title = {{{\{}E{\}}xact and {\{}A{\}}pproximate {\{}S{\}}tepdown {\{}M{\}}ethods for {\{}M{\}}ultiple {\{}H{\}}ypothesis {\{}T{\}}esting}},
+title = {{Exact and Approximate Stepdown Methods for Multiple Hypothesis Testing}},
 volume = {100},
 year = {2005}
 }
@@ -10077,7 +10077,7 @@ year = {2017}
 }
 @misc{Rosapepe.2001,
 author = {Rosapepe, James C},
-title = {{{\{}H{\}}alf {\{}W{\}}ay {\{}H{\}}ome: {\{}R{\}}omania's {\{}A{\}}bandoned {\{}C{\}}hildren {\{}T{\}}en {\{}Y{\}}ears {\{}A{\}}fter {\{}T{\}}he {\{}R{\}}evolution}},
+title = {{Half Way Home: Romania's Abandoned Children Ten Years After The Revolution}},
 url = {http://www.usembassy.ro/USAID/Documents/10YearsRetrospective.pdf},
 year = {2001}
 }
@@ -10095,7 +10095,7 @@ author = {Rosenzweig, Mark R and Schultz, Paul T},
 journal = {The Journal of Political Economy},
 number = {5},
 pages = {723--746},
-title = {{{\{}E{\}}stimating a {\{}H{\}}ousehold {\{}P{\}}roduction {\{}F{\}}unction: {\{}H{\}}eterogeneity, the {\{}D{\}}emand for {\{}H{\}}ealth {\{}I{\}}nputs, and {\{}T{\}}heir {\{}E{\}}ffect on {\{}B{\}}irth {\{}W{\}}eight}},
+title = {{Estimating a Household Production Function: Heterogeneity, the Demand for Health Inputs, and Their Effect on Birth Weight}},
 volume = {91},
 year = {1983}
 }
@@ -10103,11 +10103,11 @@ year = {1983}
 abstract = {demographic behavior, family organisation composition constraints technology incentive structure demographics fertility marriage contraception family behavior effects of targeted welfare programs depend on relationship across and within households efficacy of macro programs is conditioned by extent and character of intergenerational family economics cost of welfare policies supporting children depend on response of family and marriage decision to economic incentives theoretical literature of the family formation structure ressource allocation dissolution building blocks of microeconmics preferences techknologies concepts and tools public good transferable utility programming game theory cooperative noncooperative$\backslash$new},
 address = {Amsterdam, NL},
 author = {Rosenzweig, Mark R and Stark, Oded},
-booktitle = {{\{}H{\}}andbook of {\{}P{\}}opulation and {\{}F{\}}amily {\{}E{\}}conomics},
+booktitle = {Handbook of Population and Family Economics},
 editor = {Rosenzweig, Mark R and Stark, Oded},
 pages = {1--17},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}I{\}}ntroduction: {\{}P{\}}opulation and {\{}F{\}}amily {\{}E{\}}conomics}},
+title = {{Introduction: Population and Family Economics}},
 volume = {1A},
 year = {1997}
 }
@@ -10116,7 +10116,7 @@ author = {Rosenzweig, Mark R and Wolpin, Kenneth I},
 journal = {Journal of Economic Literature},
 number = {4},
 pages = {827--874},
-title = {{{\{}N{\}}atural ''{\{}N{\}}atural'' {\{}E{\}}xperiments in {\{}E{\}}conomics}},
+title = {{Natural ''Natural'' Experiments in Economics}},
 volume = {38},
 year = {2000}
 }
@@ -10125,7 +10125,7 @@ author = {Rosenzweig, Mark R and Wolpin, Kenneth I},
 journal = {Econometrica},
 number = {2},
 pages = {303--326},
-title = {{{\{}S{\}}isters,{\$}{\~{}}{\$}{\{}S{\}}iblings, and {\{}M{\}}others:{\$}{\~{}}{\$}{\{}T{\}}he {\{}E{\}}ffect of {\{}T{\}}een-{\{}A{\}}ge {\{}C{\}}hildbearing on {\{}B{\}}irth {\{}O{\}}utcomes ind a {\{}D{\}}ynamic {\{}F{\}}amily {\{}C{\}}ontext}},
+title = {{Sisters, Siblings, and Mothers: The Effect of Teen-Age Childbearing on Birth Outcomes ind a Dynamic Family Context}},
 volume = {63},
 year = {1995}
 }
@@ -10134,7 +10134,7 @@ author = {Rosenzweig, Mark R and Wolpin, Kenneth I},
 journal = {Journal of Econometrics},
 number = {1-2},
 pages = {205--228},
-title = {{{\{}I{\}}nequality at {\{}B{\}}irth:{\$}{\~{}}{\$}{\{}T{\}}he {\{}S{\}}cope for {\{}P{\}}olicy {\{}I{\}}ntervention}},
+title = {{Inequality at Birth: The Scope for Policy Intervention}},
 volume = {50},
 year = {1991}
 }
@@ -10150,7 +10150,7 @@ author = {Ross, Catherine E and Mirowsky, John},
 journal = {Demography},
 number = {4},
 pages = {445--460},
-title = {{{\{}R{\}}efining the {\{}A{\}}ssocation between {\{}E{\}}ducation and {\{}H{\}}ealth: {\{}T{\}}he {\{}E{\}}ffects of {\{}Q{\}}uantity, {\{}C{\}}redential, and {\{}S{\}}electivity}},
+title = {{Refining the Assocation between Education and Health: The Effects of Quantity, Credential, and Selectivity}},
 volume = {36},
 year = {1999}
 }
@@ -10175,18 +10175,18 @@ year = {2008}
 @incollection{Rotter.1972b,
 address = {New York, NY},
 author = {Rotter, Julian B},
-booktitle = {{\{}A{\}}pplications of a {\{}S{\}}ocial {\{}L{\}}earning {\{}T{\}}heory of {\{}P{\}}ersonality},
+booktitle = {Applications of a Social Learning Theory of Personality},
 editor = {Rotter, Julian B and Chance, June E and Phares, Jerry E},
 pages = {260--295},
 publisher = {Holt, Rinehart, and Winston},
-title = {{{\{}G{\}}eneralized {\{}E{\}}xpectancies for {\{}I{\}}nternal {\{}V{\}}ersus {\{}E{\}}xternal {\{}C{\}}ontrol of {\{}R{\}}einforcement}},
+title = {{Generalized Expectancies for Internal Versus External Control of Reinforcement}},
 year = {1972}
 }
 @book{Rotter.1972,
 address = {New York, NY},
 editor = {Rotter, Julian B and Chance, June E and Phares, Jerry E},
 publisher = {Holt, Rinehart, and Winston},
-title = {{{\{}A{\}}pplications of a {\{}S{\}}ocial {\{}L{\}}earning {\{}T{\}}heory of {\{}P{\}}ersonality}},
+title = {{Applications of a Social Learning Theory of Personality}},
 year = {1972}
 }
 @article{Roy.1951,
@@ -10194,7 +10194,7 @@ author = {Roy, A D},
 journal = {Oxford Economic Papers},
 number = {2},
 pages = {135--146},
-title = {{{\{}S{\}}ome {\{}T{\}}houghts on the {\{}D{\}}istribution of {\{}E{\}}arnings}},
+title = {{Some Thoughts on the Distribution of Earnings}},
 volume = {3},
 year = {1951}
 }
@@ -10203,7 +10203,7 @@ author = {Rubin, Donald B},
 journal = {The Annals of Statistics},
 number = {1},
 pages = {130--134},
-title = {{{\{}T{\}}he {\{}B{\}}yesian {\{}B{\}}ootstrap}},
+title = {{The Byesian Bootstrap}},
 volume = {9},
 year = {1981}
 }
@@ -10272,7 +10272,7 @@ author = {Rutter, Michael},
 journal = {Journal of Child Psychology and Psychiatry},
 number = {4},
 pages = {465--476},
-title = {{{\{}D{\}}evelopmental {\{}C{\}}atch-{\{}U{\}}p, {\{}A{\}}nd {\{}D{\}}eficit, {\{}F{\}}ollowing {\{}A{\}}doption {\{}A{\}}fter {\{}S{\}}evere {\{}G{\}}lobal {\{}E{\}}arly {\{}P{\}}rivation}},
+title = {{Developmental Catch-Up, And Deficit, Following Adoption After Severe Global Early Privation}},
 volume = {39},
 year = {1998}
 }
@@ -10280,7 +10280,7 @@ year = {1998}
 address = {Oxford, UK},
 author = {Rutter, Michael},
 publisher = {Blackwell Publishers},
-title = {{{\{}G{\}}enes and {\{}B{\}}ehavior:{\$}{\~{}}{\$}{\{}N{\}}ature-{\{}N{\}}urture {\{}I{\}}nterplay {\{}E{\}}xplained}},
+title = {{Genes and Behavior: Nature-Nurture Interplay Explained}},
 year = {2006}
 }
 @article{Rutter.2006b,
@@ -10288,7 +10288,7 @@ author = {Rutter, Michael and Moffitt, Terrie E and Caspi, Avshalom},
 journal = {Journal of Child Psychology and Psychiatry},
 number = {3/4},
 pages = {226--261},
-title = {{{\{}G{\}}ene-{\{}E{\}}nvironment {\{}I{\}}nterplay and {\{}P{\}}sychopathology:{\$}{\~{}}{\$}{\{}M{\}}ultiple {\{}V{\}}arieties but {\{}R{\}}eal{\$}{\~{}}{\$}{\{}E{\}}ffects}},
+title = {{Gene-Environment Interplay and Psychopathology: Multiple Varieties but Real Effects}},
 volume = {47},
 year = {2006}
 }
@@ -10304,18 +10304,18 @@ year = {2001}
 @article{Salm.2008,
 author = {Salm, Martin and Schunk, Daniel},
 journal = {IZA Discussion Paper},
-title = {{{\{}T{\}}he {\{}R{\}}ole of {\{}C{\}}hildhood {\{}H{\}}ealth for the {\{}I{\}}ntergenerational {\{}T{\}}ransmission of {\{}H{\}}uman {\{}C{\}}apital: {\{}E{\}}vidence from {\{}A{\}}dministrative {\{}D{\}}ata}},
+title = {{The Role of Childhood Health for the Intergenerational Transmission of Human Capital: Evidence from Administrative Data}},
 volume = {No. 3646},
 year = {2008}
 }
 @incollection{Salovey.1998,
 address = {New York, NY},
 author = {Salovey, Peter and Rothman, Alexander J and Rodin, Judith},
-booktitle = {{\{}T{\}}he {\{}H{\}}andbook of {\{}S{\}}ocial {\{}P{\}}sychology},
+booktitle = {The Handbook of Social Psychology},
 editor = {Gilbert, Daniel T and Fiske, Susan T and Lindzey, Gardner},
 pages = {662--683},
 publisher = {Oxford University Press},
-title = {{{\{}H{\}}ealt {\{}B{\}}ehavior}},
+title = {{Healt Behavior}},
 volume = {2},
 year = {1998}
 }
@@ -10324,7 +10324,7 @@ author = {Sandberg, John F and Hofferth, Sandra L},
 journal = {Demography},
 number = {3},
 pages = {423--436},
-title = {{{\{}C{\}}hanges in {\{}C{\}}hildren's {\{}T{\}}ime with {\{}P{\}}arents, {\{}U{\}}.{\{}S{\}}. 1981 - 1997}},
+title = {{Changes in Children's Time with Parents, U.S. 1981 - 1997}},
 volume = {38},
 year = {2001}
 }
@@ -10351,7 +10351,7 @@ author = {Saudino, Kimberly J and Zapfe, Jeffrey A},
 journal = {Child Development},
 number = {4},
 pages = {930--943},
-title = {{{\{}G{\}}enetic {\{}I{\}}nfluences on {\{}A{\}}ctivity {\{}L{\}}evel in {\{}E{\}}arly {\{}C{\}}hildhood: {\{}D{\}}o {\{}S{\}}ituations {\{}M{\}}atter?}},
+title = {{Genetic Influences on Activity Level in Early Childhood: Do Situations Matter?}},
 volume = {79},
 year = {2008}
 }
@@ -10373,7 +10373,7 @@ year = {1951}
 @book{Savage.1954,
 address = {Hoboken, NJ},
 author = {Savage, Leonard J},
-publisher = {John Wiley {\&} Sons, Inc.},
+publisher = {John Wiley \& Sons, Inc.},
 title = {{The Foundations of Statistics}},
 year = {1954}
 }
@@ -10381,7 +10381,7 @@ year = {1954}
 author = {Schennach, Susanne},
 journal = {Econometric Theory},
 pages = {1046--1093},
-title = {{{\{}N{\}}onparametric {\{}E{\}}stimation in the {\{}P{\}}resence of {\{}M{\}}easurement {\{}E{\}}rror}},
+title = {{Nonparametric Estimation in the Presence of Measurement Error}},
 volume = {20},
 year = {2004}
 }
@@ -10390,14 +10390,14 @@ author = {Schennach, Susanne},
 journal = {Econometrica},
 number = {1},
 pages = {33--75},
-title = {{{\{}E{\}}stimation of {\{}N{\}}onlinear {\{}M{\}}odels with {\{}M{\}}easurement {\{}E{\}}rror}},
+title = {{Estimation of Nonlinear Models with Measurement Error}},
 volume = {72},
 year = {2004}
 }
 @article{Schennach.2010,
 author = {Schennach, Susanne and White, Halbert and Chalak, Karim},
 journal = {Working Paper},
-title = {{{\{}L{\}}ocal {\{}I{\}}ndirect {\{}L{\}}east {\{}S{\}}quares and {\{}A{\}}verage {\{}M{\}}arginal {\{}E{\}}¤ects in {\{}N{\}}onseparable {\{}S{\}}tructural {\{}S{\}}ystems}},
+title = {{Local Indirect Least Squares and Average Marginal E¤ects in Nonseparable Structural Systems}},
 year = {2010}
 }
 @article{Schlesinger.1979,
@@ -10427,7 +10427,7 @@ year = {2012}
 }
 @article{Schneider.2010,
 author = {{Schneider Hilmar; Uhlendorff}, Arne; Zimmermann Klaus F},
-journal = {Zeitschrift f{\"{u}}r Arbeitsmarkt- und Berufsforschung},
+journal = {Zeitschrift f\"{u}r Arbeitsmarkt- und Berufsforschung},
 title = {{Mit Workfare aus der Sozialhilfe? Lehren aus einem Modellprojekt}},
 year = {2010}
 }
@@ -10435,7 +10435,7 @@ year = {2010}
 address = {Berlin, GER},
 author = {Schofield, Norman},
 publisher = {Springer},
-title = {{{\{}M{\}}athematical {\{}M{\}}ethods in{\$}{\~{}}{\$}{\{}E{\}}conomics and {\{}S{\}}ocial {\{}C{\}}hoice}},
+title = {{Mathematical Methods in Economics and Social Choice}},
 year = {2004}
 }
 @article{Schorfheide.2012,
@@ -10451,13 +10451,13 @@ year = {2012}
 address = {Amsterdam, NL},
 editor = {Schultz, Paul T and Stauss, John A},
 publisher = {Elsevier Science},
-title = {{{\{}H{\}}andbook of {\{}D{\}}evelopment {\{}E{\}}conomics}},
+title = {{Handbook of Development Economics}},
 year = {2007}
 }
 @article{Schupp.2008,
-author = {Schupp, J{\"{u}}rgen and Herrmann, Sabrina and Jaensch, Peter and Lang, Frieder R},
-journal = {DIW{\$}{\~{}}{\$}Data Documentation},
-title = {{{\{}E{\}}rfassung {\{}K{\}}ognitiver {\{}L{\}}eistungspotentiale {\{}E{\}}rwachsener im {\{}S{\}}ozio-oekonomischen {\{}P{\}}anel ({\{}S{\}}{\{}O{\}}{\{}E{\}}{\{}P{\}})}},
+author = {Schupp, J\"{u}rgen and Herrmann, Sabrina and Jaensch, Peter and Lang, Frieder R},
+journal = {DIW Data Documentation},
+title = {{Erfassung Kognitiver Leistungspotentiale Erwachsener im Sozio-oekonomischen Panel (SOEP)}},
 volume = {32},
 year = {2008}
 }
@@ -10465,7 +10465,7 @@ year = {2008}
 address = {Ypsilanti, MI},
 author = {Schweinhart, Lawrence J and Montie, Jeanne and Xiang, Zongping and Barnett, Steve W and Belfield, Clive R and Nores, Milagros},
 publisher = {High/Scope Press},
-title = {{{\{}L{\}}ifetime {\{}E{\}}ffects:{\$}{\~{}}{\$}{\{}T{\}}he {\{}H{\}}igh/{\{}S{\}}cope {\{}P{\}}erry {\{}P{\}}reschool {\{}S{\}}tudy {\{}T{\}}hrough {\{}A{\}}ge 40}},
+title = {{Lifetime Effects: The High/Scope Perry Preschool Study Through Age 40}},
 year = {2005}
 }
 @article{Schwerdt.2011,
@@ -10494,7 +10494,7 @@ author = {Segal, Carmit},
 journal = {The Journal of Human Resources},
 number = {4},
 pages = {783--814},
-title = {{{\{}C{\}}lassroom {\{}B{\}}ehavior}},
+title = {{Classroom Behavior}},
 volume = {43},
 year = {2008}
 }
@@ -10508,21 +10508,21 @@ year = {2009}
 address = {Cambridge, MA},
 author = {Sen, Armatya K},
 publisher = {Harvard University Press},
-title = {{{\{}I{\}}nequality {\{}R{\}}eexamined}},
+title = {{Inequality Reexamined}},
 year = {1992}
 }
 @book{Sen.2000,
 address = {New York, NY},
 author = {Sen, Armatya K},
 publisher = {Anchor Books},
-title = {{{\{}D{\}}evelopment as {\{}F{\}}reedom}},
+title = {{Development as Freedom}},
 year = {2000}
 }
 @book{Sewell.1975,
 address = {New York, NY},
 author = {Sewell, William H and Hauser, Robert M},
 publisher = {Academic Press},
-title = {{{\{}E{\}}ducation, {\{}O{\}}ccupation and {\{}E{\}}arnings: {\{}A{\}}chievement in the {\{}E{\}}arly {\{}C{\}}areer}},
+title = {{Education, Occupation and Earnings: Achievement in the Early Career}},
 year = {1975}
 }
 @article{Shaikh.2009,
@@ -10538,13 +10538,13 @@ year = {2011}
 author = {Shaikh, Azeem and Vytlacil, Edward J},
 journal = {NBER Technical Working Paper},
 number = {307},
-title = {{{\{}L{\}}imited {\{}D{\}}ependent {\{}V{\}}ariable {\{}M{\}}odels and {\{}B{\}}ounds on {\{}T{\}}reatment {\{}E{\}}ffects:{\$}{\~{}}{\$}{\{}A{\}} {\{}N{\}}onparametric {\{}A{\}}nalysis}},
+title = {{Limited Dependent Variable Models and Bounds on Treatment Effects: A Nonparametric Analysis}},
 year = {2005}
 }
 @article{Shakotko.1980,
-author = {Shakotko, Robert{\$}{\~{}}{\$}A and Edwards, Linda N and Grossman, Michael},
+author = {Shakotko, Robert A and Edwards, Linda N and Grossman, Michael},
 journal = {NBER Working Paper},
-title = {{{\{}A{\}}n {\{}E{\}}xploration of the {\{}D{\}}ynamic {\{}R{\}}elationship {\{}B{\}}etween{\$}{\~{}}{\$}{\{}H{\}}ealth and {\{}C{\}}ognitive {\{}D{\}}evelopment in {\{}A{\}}dolescence}},
+title = {{An Exploration of the Dynamic Relationship Between Health and Cognitive Development in Adolescence}},
 volume = {454},
 year = {1980}
 }
@@ -10553,7 +10553,7 @@ author = {Shea, John},
 journal = {Journal of Public Economics},
 number = {2},
 pages = {155--184},
-title = {{{\{}D{\}}oes {\{}P{\}}arent's {\{}M{\}}oney {\{}M{\}}atter?}},
+title = {{Does Parent's Money Matter?}},
 volume = {77},
 year = {2000}
 }
@@ -10572,7 +10572,7 @@ year = {2010}
 address = {Washington, D.C},
 editor = {Shonkoff, Jack P and Phillips, Deborah},
 publisher = {National Academy Press},
-title = {{{\{}F{\}}rom {\{}N{\}}eurons to {\{}N{\}}eighborhoods: {\{}T{\}}he {\{}S{\}}cience of {\{}E{\}}arly {\{}C{\}}hild {\{}D{\}}evelopment}},
+title = {{From Neurons to Neighborhoods: The Science of Early Child Development}},
 year = {2000}
 }
 @article{Shorrocks.1978,
@@ -10580,7 +10580,7 @@ author = {Shorrocks, Anthony},
 journal = {Journal of Economic Theory},
 number = {2},
 pages = {376--393},
-title = {{{\{}I{\}}ncome {\{}I{\}}nequality and {\{}I{\}}ncome {\{}M{\}}obility}},
+title = {{Income Inequality and Income Mobility}},
 volume = {19},
 year = {1978}
 }
@@ -10589,14 +10589,14 @@ author = {Shumway, Robert H and Stoffer, David S},
 journal = {Journal of TIme Series Analysis},
 number = {4},
 pages = {253--264},
-title = {{{\{}A{\}}n {\{}A{\}}pproach to {\{}T{\}}ime {\{}S{\}}eries {\{}S{\}}moothing and {\{}F{\}}orecasting {\{}U{\}}sing the {\{}E{\}}{\{}M{\}} {\{}A{\}}lgorithm}},
+title = {{An Approach to Time Series Smoothing and Forecasting Using the EM Algorithm}},
 volume = {3},
 year = {1982}
 }
 @book{Silverman.1986,
 address = {London, United Kingdom},
 author = {Silverman, B W},
-publisher = {Chapman {\&} Hall},
+publisher = {Chapman \& Hall},
 title = {{Density Estimation}},
 year = {1986}
 }
@@ -10612,17 +10612,17 @@ year = {1992}
 @incollection{Singer.1985,
 address = {Cambridge, MA},
 author = {Singer, Burton and Heckman, James J},
-booktitle = {{\{}L{\}}ongitudinal {\{}A{\}}nalysis of {\{}L{\}}abor {\{}M{\}}arket {\{}D{\}}ata},
+booktitle = {Longitudinal Analysis of Labor Market Data},
 editor = {Heckman, James J and Singer, Burton},
 publisher = {Cambridge University Press},
-title = {{{\{}A{\}}lternative {\{}M{\}}ethods for {\{}E{\}}valuating the {\{}I{\}}mpact of {\{}I{\}}nterventions}},
+title = {{Alternative Methods for Evaluating the Impact of Interventions}},
 year = {1985}
 }
 @article{Sklar.1959,
 author = {Sklar, A},
 journal = {Publications de l'Institute de Statistique de l'Universite de Paris},
 pages = {229--231},
-title = {{{\{}F{\}}onctions de {\{}R{\}}eparition a n {\{}D{\}}imensions et {\{}L{\}}eurs {\{}M{\}}arges}},
+title = {{Fonctions de Reparition a n Dimensions et Leurs Marges}},
 volume = {8},
 year = {1959}
 }
@@ -10646,7 +10646,7 @@ year = {1961}
 @article{Smith.2008,
 author = {Smith, James P},
 journal = {Proceedings of the National Academy of Science},
-title = {{{\{}D{\}}iabetes and the {\{}R{\}}ise of the {\{}S{\}}{\{}E{\}}{\{}S{\}}{\$}{\~{}}{\$}{\{}H{\}}ealth {\{}G{\}}radient}},
+title = {{Diabetes and the Rise of the SES Health Gradient}},
 volume = {forthcomin},
 year = {2008}
 }
@@ -10655,7 +10655,7 @@ author = {Smith, Murray},
 journal = {Econometrics Journal},
 number = {6},
 pages = {99--123},
-title = {{{\{}M{\}}odeling {\{}S{\}}ample {\{}S{\}}election using {\{}A{\}}chimedean {\{}C{\}}opulas}},
+title = {{Modeling Sample Selection using Achimedean Copulas}},
 year = {2003}
 }
 @article{Smith.2005,
@@ -10663,7 +10663,7 @@ author = {Smith, Murray},
 journal = {Economic Record},
 number = {255},
 pages = {S47----S57},
-title = {{{\{}U{\}}sing {\{}C{\}}opulas to {\{}M{\}}odel {\{}S{\}}witching {\{}R{\}}egimes with an {\{}A{\}}pplication to {\{}C{\}}hild {\{}L{\}}abour}},
+title = {{Using Copulas to Model Switching Regimes with an Application to Child Labour}},
 volume = {81},
 year = {2005}
 }
@@ -10672,7 +10672,7 @@ author = {Solon, Gary},
 journal = {Journal of Economic Perspectives},
 number = {3},
 pages = {59--66},
-title = {{{\{}C{\}}ross-{\{}C{\}}ountry {\{}D{\}}ifferences in {\{}I{\}}ntergenerational {\{}E{\}}arnings {\{}M{\}}obility}},
+title = {{Cross-Country Differences in Intergenerational Earnings Mobility}},
 volume = {16},
 year = {2002}
 }
@@ -10681,7 +10681,7 @@ author = {Solon, Gary},
 journal = {The Review of Economics and Statistics},
 number = {1},
 pages = {172--174},
-title = {{{\{}B{\}}iases in the {\{}E{\}}stimation of {\{}I{\}}ntergenerational {\{}E{\}}arnings {\{}C{\}}orrelations}},
+title = {{Biases in the Estimation of Intergenerational Earnings Correlations}},
 volume = {71},
 year = {1989}
 }
@@ -10690,18 +10690,18 @@ author = {Solon, Gary},
 journal = {American Economic Review},
 number = {3},
 pages = {393--408},
-title = {{{\{}I{\}}ntergenerational {\{}I{\}}ncome {\{}M{\}}obility in the {\{}U{\}}nited {\{}S{\}}tates}},
+title = {{Intergenerational Income Mobility in the United States}},
 volume = {82},
 year = {1992}
 }
 @incollection{Solon.1999,
 address = {Amsterdam, NL},
 author = {Solon, Gary},
-booktitle = {{\{}H{\}}andbook of {\{}L{\}}abor {\{}E{\}}conomics},
+booktitle = {Handbook of Labor Economics},
 editor = {Ashenfelter, Orley and Card, David},
 pages = {1761--1800},
 publisher = {North-Holland Publishing Company},
-title = {{{\{}I{\}}ntergenerational {\{}M{\}}obility in the {\{}L{\}}abor {\{}M{\}}arket}},
+title = {{Intergenerational Mobility in the Labor Market}},
 volume = {3A},
 year = {1999}
 }
@@ -10715,14 +10715,14 @@ pages = {595},
 pmid = {20941455},
 publisher = {Wiley},
 title = {{Introduction to Stochastic Search and Optimization}},
-url = {http://books.google.com/books?id=3gsh1uJcRJEC{\&}pgis=1{\%}5Cnhttp://books.google.com/books?hl=en{\&}lr={\&}id=f66OIvvkKnAC{\&}oi=fnd{\&}pg=PA1{\&}dq=Introduction+to+Stochastic+Search+and+Optimization.+Estimation,+Simulation+and+Control{\&}ots=AjyA4cKu{\_}Y{\&}sig=zM0bUiz2TfltOmKfuAJB},
+url = {http://books.google.com/books?id=3gsh1uJcRJEC&pgis=1{\%}5Cnhttp://books.google.com/books?hl=en&lr=&id=f66OIvvkKnAC&oi=fnd&pg=PA1&dq=Introduction+to+Stochastic+Search+and+Optimization.+Estimation,+Simulation+and+Control&ots=AjyA4cKu{\_}Y&sig=zM0bUiz2TfltOmKfuAJB},
 year = {2003}
 }
 @article{Spearman.1904,
 author = {Spearman, Charles},
 journal = {American Journal of Psychology},
 pages = {201--293},
-title = {{''{\{}G{\}}eneral {\{}I{\}}ntelligence'', {\{}O{\}}bjectively {\{}D{\}}etermined and {\{}M{\}}easured}},
+title = {{''General Intelligence'', Objectively Determined and Measured}},
 volume = {15},
 year = {1904}
 }
@@ -10744,11 +10744,11 @@ year = {2009}
 @incollection{Stafford.2005,
 address = {Amsterdam, NL},
 author = {Stafford, Frank and Yeung, Wei-Jun J},
-booktitle = {{\{}T{\}}he {\{}E{\}}conomics of {\{}T{\}}ime {\{}U{\}}se},
+booktitle = {The Economics of Time Use},
 editor = {Hammermesh, Daniel S and Pfann, Gerard A},
 pages = {289--313},
 publisher = {Elsevier Science},
-title = {{{\{}T{\}}he {\{}D{\}}istribution of {\{}C{\}}hildren's {\{}D{\}}evelopmental {\{}R{\}}esources}},
+title = {{The Distribution of Children's Developmental Resources}},
 year = {2005}
 }
 @article{Staghoej.2010,
@@ -10767,11 +10767,11 @@ title = {{Is Contracting-Out Intensified Placement Services More Effective than 
 year = {2011}
 }
 @article{Stephan.2006,
-author = {Stephan, Gesine and R{\"{a}}ssler, Susanne and Schewe, Torben},
-journal = {Zeitschrift f{\"{u}}r Arbeitsmarkt- und Berufsforschung},
+author = {Stephan, Gesine and R\"{a}ssler, Susanne and Schewe, Torben},
+journal = {Zeitschrift f\"{u}r Arbeitsmarkt- und Berufsforschung},
 number = {3-4},
 pages = {447--465},
-title = {{Das TrEffeR-Projekt der Bundesagentur f{\"{u}}r Arbeit: Die Wirkung von Ma{\{}{\ss}{\}}nahmen Aktiver Arbeitsmarktpolitik}},
+title = {{Das TrEffeR-Projekt der Bundesagentur f\"{u}r Arbeit: Die Wirkung von Ma{\{}{\ss}{\}}nahmen Aktiver Arbeitsmarktpolitik}},
 volume = {39},
 year = {2006}
 }
@@ -10789,14 +10789,14 @@ author = {Stiggins, Richard J},
 journal = {Educational Measurement: Issues and Practice},
 number = {3},
 pages = {33--42},
-title = {{{\{}D{\}}esign and {\{}D{\}}evelopment of {\{}P{\}}erformance {\{}A{\}}ssessments}},
+title = {{Design and Development of Performance Assessments}},
 volume = {6},
 year = {1987}
 }
 @article{Stinebrickner.2008,
 author = {Stinebrickner, Ralph and Stinebrickner, Todd R},
 journal = {American Economic Review},
-title = {{{\{}C{\}}redit {\{}C{\}}onstraints and {\{}C{\}}ollege {\{}A{\}}ttrition}},
+title = {{Credit Constraints and College Attrition}},
 volume = {forthcomin},
 year = {2008}
 }
@@ -10819,7 +10819,7 @@ volume = {51},
 year = {2004}
 }
 @article{Stoye.2011,
-author = {Stoye, J{\"{o}}rg},
+author = {Stoye, J\"{o}rg},
 journal = {Journal of Economic Theory},
 number = {6},
 pages = {2226--2251},
@@ -10828,7 +10828,7 @@ volume = {146},
 year = {2011}
 }
 @article{Stoye.2012,
-author = {Stoye, J{\"{o}}rg},
+author = {Stoye, J\"{o}rg},
 journal = {Annual Review of Economics},
 pages = {257--282},
 title = {{New Perspective on Statistical Decisions Under Ambiguity}},
@@ -10840,7 +10840,7 @@ author = {Streissguth, Ann},
 journal = {Journal of Clinical Psychology in Medical Settings},
 number = {2},
 pages = {81--101},
-title = {{{\{}O{\}}ffspring {\{}E{\}}ffects of {\{}P{\}}renatal {\{}A{\}}lcohol {\{}E{\}}xposure form {\{}B{\}}irth to 25 {\{}Y{\}}ears: {\{}T{\}}he {\{}S{\}}eattle {\{}P{\}}rospective {\{}L{\}}ongitudinal {\{}S{\}}tudy}},
+title = {{Offspring Effects of Prenatal Alcohol Exposure form Birth to 25 Years: The Seattle Prospective Longitudinal Study}},
 volume = {14},
 year = {2007}
 }
@@ -10848,14 +10848,14 @@ year = {2007}
 address = {Cambridge, UK},
 editor = {Strom, Steinar},
 publisher = {Cambridge University Press},
-title = {{{\{}E{\}}conometrics and {\{}E{\}}conomic {\{}T{\}}heory in the 20th {\{}C{\}}entury}},
+title = {{Econometrics and Economic Theory in the 20th Century}},
 year = {1998}
 }
 @book{Stromsdorfer.1980,
 address = {Beverly Hills, CA},
 editor = {Stromsdorfer, S and Farkas, George},
 publisher = {Sage Publications},
-title = {{{\{}E{\}}valuation {\{}S{\}}tudies {\{}R{\}}eview {\{}A{\}}nnual}},
+title = {{Evaluation Studies Review Annual}},
 year = {1980}
 }
 @article{Strotz.1956,
@@ -10892,11 +10892,11 @@ year = {1996}
 @incollection{Suomi.1999,
 address = {New York, NY},
 author = {Suomi, Stephen J},
-booktitle = {{\{}D{\}}evelopmental {\{}H{\}}ealth and the {\{}W{\}}ealth of {\{}N{\}}ations: {\{}S{\}}ocial, {\{}B{\}}iological, and {\{}E{\}}ducational {\{}D{\}}ynamics},
+booktitle = {Developmental Health and the Wealth of Nations: Social, Biological, and Educational Dynamics},
 editor = {Keating, Daniel P and Hertzman, Clyde},
 pages = {185--200},
 publisher = {The Guilford Press},
-title = {{{\{}D{\}}evelopmental {\{}T{\}}rajectories, {\{}E{\}}arly {\{}E{\}}xperiences, and {\{}C{\}}ommunity {\{}C{\}}onsequences:{\$}{\~{}}{\$}{\{}L{\}}essons from{\$}{\~{}}{\$}{\{}S{\}}tudies with{\$}{\~{}}{\$}{\{}R{\}}hesus {\{}M{\}}onkeys}},
+title = {{Developmental Trajectories, Early Experiences, and Community Consequences: Lessons from Studies with Rhesus Monkeys}},
 year = {1999}
 }
 @article{Sweeting.2009,
@@ -10920,7 +10920,7 @@ year = {1953}
 @book{Taggart.1995,
 author = {Taggart, Robert},
 institution = {Philadelphia: Industrialization Center of America},
-title = {{{\{}Q{\}}uantum {\{}O{\}}pportunity {\{}P{\}}rogram}},
+title = {{Quantum Opportunity Program}},
 year = {1995}
 }
 @article{Tanner.1987,
@@ -10928,7 +10928,7 @@ author = {Tanner, Martin A and Wong, Wing H},
 journal = {Journal of the American Statistical Association},
 number = {398},
 pages = {528--540},
-title = {{{\{}T{\}}he {\{}C{\}}alculation of {\{}P{\}}osterior {\{}D{\}}istributions by {\{}D{\}}ata {\{}A{\}}ugmentation}},
+title = {{The Calculation of Posterior Distributions by Data Augmentation}},
 volume = {82},
 year = {1987}
 }
@@ -10946,7 +10946,7 @@ author = {Teicher, Henry},
 journal = {The Annals of Mathematical Statistics},
 number = {4},
 pages = {1265--1269},
-title = {{{\{}I{\}}dentifiability of {\{}F{\}}inite {\{}M{\}}ixtures}},
+title = {{Identifiability of Finite Mixtures}},
 volume = {34},
 year = {1963}
 }
@@ -10954,7 +10954,7 @@ year = {1963}
 author = {Temple, Judy A and Reynolds, Arthur J},
 journal = {Economics of Education Review},
 pages = {126--144},
-title = {{{\{}B{\}}enefits and {\{}C{\}}osts of {\{}I{\}}nvestment in {\{}P{\}}reschool {\{}E{\}}ducation:{\$}{\~{}}{\$}{\{}E{\}}vidence from the {\{}C{\}}hild-{\{}P{\}}arent {\{}C{\}}enters and {\{}R{\}}elated {\{}P{\}}rograms}},
+title = {{Benefits and Costs of Investment in Preschool Education: Evidence from the Child-Parent Centers and Related Programs}},
 volume = {26},
 year = {2007}
 }
@@ -10963,7 +10963,7 @@ author = {Thistlethwaite, Donald L and Campbell, Donald T},
 journal = {Journal of Educational Psychology},
 number = {6},
 pages = {309--317},
-title = {{{\{}R{\}}egression-{\{}D{\}}iscontinuity {\{}A{\}}nalysis: {\{}A{\}}n {\{}A{\}}lternative to the {\{}E{\}}x-{\{}P{\}}ost {\{}F{\}}acto {\{}E{\}}xperiment}},
+title = {{Regression-Discontinuity Analysis: An Alternative to the Ex-Post Facto Experiment}},
 volume = {51},
 year = {1960}
 }
@@ -10979,14 +10979,14 @@ year = {1934}
 @article{Tierney.1995,
 author = {Tierney, Joseph and Grossman, Jean},
 journal = {Philadelphia: Public/Private Ventures},
-title = {{{\{}M{\}}aking a {\{}D{\}}ifference: {\{}A{\}}n {\{}I{\}}mpact {\{}S{\}}tudy of {\{}B{\}}ig {\{}B{\}}rothers/ {\{}B{\}}ig {\{}S{\}}isters}},
+title = {{Making a Difference: An Impact Study of Big Brothers/ Big Sisters}},
 year = {1995}
 }
 @article{Tierney.1994,
 author = {Tierney, L},
 journal = {Annals of Statistics},
 pages = {1701--1762},
-title = {{{\{}M{\}}arkov {\{}C{\}}hains for {\{}E{\}}xploring {\{}P{\}}osterior {\{}D{\}}istributions}},
+title = {{Markov Chains for Exploring Posterior Distributions}},
 volume = {82},
 year = {1994}
 }
@@ -11009,17 +11009,17 @@ year = {1956}
 address = {Chichester},
 author = {Titterington, Mike D and Smith, Adrian F and Makov, Udi E},
 publisher = {Wiley},
-title = {{{\{}S{\}}tatistical {\{}A{\}}nalysis of {\{}F{\}}inite {\{}M{\}}ixture {\{}D{\}}istributions}},
+title = {{Statistical Analysis of Finite Mixture Distributions}},
 year = {1985}
 }
 @incollection{Todd.2007b,
 address = {Amsterdam, NL},
 author = {Todd, Petra E},
-booktitle = {{\{}H{\}}andbook of {\{}D{\}}evelopment {\{}E{\}}conomics},
+booktitle = {Handbook of Development Economics},
 editor = {Schultz, Paul T and Stauss, John A},
 pages = {3847--3894},
 publisher = {Elsevier Science},
-title = {{{\{}E{\}}valuating {\{}S{\}}ocial {\{}P{\}}rograms {\{}W{\}}ith {\{}E{\}}ndogenous {\{}P{\}}rogram {\{}P{\}}lacement and {\{}S{\}}election of the {\{}T{\}}reated}},
+title = {{Evaluating Social Programs With Endogenous Program Placement and Selection of the Treated}},
 volume = {4},
 year = {2007}
 }
@@ -11032,10 +11032,10 @@ year = {1999}
 @incollection{Todd.2008,
 address = {New York, NY},
 author = {Todd, Petra E},
-booktitle = {{\{}T{\}}he {\{}N{\}}ew {\{}P{\}}algrave {\{}D{\}}ictionary of {\{}E{\}}conomics},
+booktitle = {The New Palgrave Dictionary of Economics},
 editor = {Durlauf, Steven N and Blume, Lawrence E},
 publisher = {Palgrave},
-title = {{{\{}M{\}}atching {\{}E{\}}stimators}},
+title = {{Matching Estimators}},
 year = {2008}
 }
 @article{Todd.2006,
@@ -11043,7 +11043,7 @@ author = {Todd, Petra E and Wolpin, Kenneth I},
 journal = {American Economic Review},
 number = {5},
 pages = {1384--1417},
-title = {{{\{}A{\}}ssessing the {\{}I{\}}mpact of a {\{}S{\}}chool {\{}S{\}}ubsidy {\{}P{\}}rogram in {\{}M{\}}exico: {\{}U{\}}sing a {\{}S{\}}ocial {\{}E{\}}xperiment to {\{}V{\}}alidate a {\{}D{\}}ynamic {\{}B{\}}ehavioral {\{}M{\}}odel of {\{}C{\}}hild {\{}S{\}}chooling and {\{}F{\}}ertility}},
+title = {{Assessing the Impact of a School Subsidy Program in Mexico: Using a Social Experiment to Validate a Dynamic Behavioral Model of Child Schooling and Fertility}},
 volume = {96},
 year = {2006}
 }
@@ -11052,7 +11052,7 @@ author = {Todd, Petra E and Wolpin, Kenneth I},
 journal = {Journal of Human Capital},
 number = {1},
 pages = {91--136},
-title = {{{\{}T{\}}he {\{}P{\}}roduction of {\{}C{\}}ognitive {\{}A{\}}chievement in {\{}C{\}}hildren: {\{}H{\}}ome, {\{}S{\}}chool and {\{}R{\}}acial {\{}T{\}}est {\{}S{\}}core {\{}G{\}}aps'''}},
+title = {{The Production of Cognitive Achievement in Children: Home, School and Racial Test Score Gaps'''}},
 volume = {1},
 year = {2007}
 }
@@ -11061,7 +11061,7 @@ author = {Todd, Petra E and Wolpin, Kenneth I},
 journal = {The Economic Journal},
 number = {485},
 pages = {F3----F33},
-title = {{{\{}O{\}}n the {\{}S{\}}pecification and {\{}E{\}}stimation of the {\{}P{\}}roduction {\{}F{\}}unction for {\{}C{\}}ognitive {\{}A{\}}chievement}},
+title = {{On the Specification and Estimation of the Production Function for Cognitive Achievement}},
 volume = {113},
 year = {2003}
 }
@@ -11083,7 +11083,7 @@ year = {2010}
 @article{Todd.2006b,
 author = {Todd, Petra E and Wolpin, Kenneth I},
 journal = {Working Paper},
-title = {{{\{}E{\}}x {\{}A{\}}nte {\{}E{\}}valuation of {\{}S{\}}ocial {\{}P{\}}rograms}},
+title = {{Ex Ante Evaluation of Social Programs}},
 year = {2006}
 }
 @article{Tomes.1981,
@@ -11091,7 +11091,7 @@ author = {Tomes, Nigel},
 journal = {Journal of Political Economy},
 number = {5},
 pages = {928--958},
-title = {{{\{}T{\}}he {\{}F{\}}amily, {\{}I{\}}nheritance and the {\{}I{\}}ntergenerational {\{}T{\}}ransmission of {\{}I{\}}nequality}},
+title = {{The Family, Inheritance and the Intergenerational Transmission of Inequality}},
 volume = {89},
 year = {1981}
 }
@@ -11099,7 +11099,7 @@ year = {1981}
 address = {Washington, D.C.},
 author = {Tourangeau, Karen and Le, Thanh and Nord, Christine and Sorongon, Alberto G and Chapman, Chris},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-99 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}E{\}}igth-{\{}G{\}}rade {\{}M{\}}ethodology {\{}R{\}}eport}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-99 (ECLS-K): Eigth-Grade Methodology Report}},
 year = {2009}
 }
 @book{Tourangeau.2006,
@@ -11107,7 +11107,7 @@ address = {Washington, D.C},
 author = {Tourangeau, Karen and Nord, Christine and L{\`{e}}, Thanh and Pollack, Judith M and Atkins-Brunett, Sally},
 institution = {National Center of Education Statistics},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-1999 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}C{\}}ombined {\{}U{\}}ser's {\{}M{\}}anual for the {\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}} {\{}F{\}}ifth {\{}G{\}}rade {\{}D{\}}ata {\{}F{\}}iles and {\{}E{\}}lectronic {\{}C{\}}odebooks}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-1999 (ECLS-K): Combined User's Manual for the ECLS-K Fifth Grade Data Files and Electronic Codebooks}},
 year = {2006}
 }
 @book{Tourangeau.2002,
@@ -11115,21 +11115,21 @@ address = {Washington, D.C},
 author = {Tourangeau, Karen and Nord, Christine and L{\`{e}}, Thanh and Pollack, Judith M and Atkins-Brunett, Sally},
 institution = {National Center of Education Statistics},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-1999 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}C{\}}ombined {\{}U{\}}ser's {\{}M{\}}anual for the {\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}} {\{}F{\}}irst {\{}G{\}}rade {\{}D{\}}ata {\{}F{\}}iles and {\{}E{\}}lectronic {\{}C{\}}odebooks}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-1999 (ECLS-K): Combined User's Manual for the ECLS-K First Grade Data Files and Electronic Codebooks}},
 year = {2002}
 }
 @book{Tourangeau.2009b,
 address = {Washington, D.C.},
 author = {Tourangeau, Karen and Nord, Christine and Sorongon, Alberto G and Najarian, Michelle},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-99 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}C{\}}ombined {\{}U{\}}ser's {\{}M{\}}anual}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-99 (ECLS-K): Combined User's Manual}},
 year = {2009}
 }
 @book{Tourangeau.2005,
 address = {Washington, D.C.},
 author = {Tourangeau, Karen and {Thanh Le} and {Christine Nord}},
 publisher = {U.S. Department of Education},
-title = {{{\{}E{\}}arly {\{}C{\}}hildhood {\{}L{\}}ongitudinal {\{}S{\}}tudy, {\{}K{\}}indergarten {\{}C{\}}lass of 1998-99 ({\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}}): {\{}F{\}}ifth {\{}G{\}}rade {\{}M{\}}ethodology {\{}R{\}}eport}},
+title = {{Early Childhood Longitudinal Study, Kindergarten Class of 1998-99 (ECLS-K): Fifth Grade Methodology Report}},
 year = {2005}
 }
 @article{Townsend.2006,
@@ -11153,7 +11153,7 @@ author = {Trivedi, Pravin K and Zimmer, David M},
 journal = {Foundations and Trends in Econometrics},
 number = {1},
 pages = {1--111},
-title = {{{\{}C{\}}opula {\{}M{\}}odeling:{\$}{\~{}}{\$}{\{}A{\}}n {\{}I{\}}ntroduction for {\{}P{\}}ractitioners}},
+title = {{Copula Modeling: An Introduction for Practitioners}},
 volume = {1},
 year = {2005}
 }
@@ -11168,7 +11168,7 @@ author = {Tunali, Insan},
 journal = {International Economic Review},
 number = {4},
 pages = {893--920},
-title = {{{\{}R{\}}ationality of {\{}M{\}}igration}},
+title = {{Rationality of Migration}},
 volume = {41},
 year = {2000}
 }
@@ -11193,14 +11193,14 @@ year = {1936}
 address = {Washington, D.C.},
 author = {{U.S. Department of Education}},
 publisher = {U.S. Department of Education},
-title = {{{\{}U{\}}ser's {\{}M{\}}anual for the {\{}E{\}}{\{}C{\}}{\{}L{\}}{\{}S{\}}-{\{}K{\}} {\{}F{\}}irst {\{}G{\}}rade {\{}P{\}}ublic-{\{}U{\}}se {\{}D{\}}ata {\{}F{\}}iles and {\{}E{\}}lectronic {\{}C{\}}odebook}},
+title = {{User's Manual for the ECLS-K First Grade Public-Use Data Files and Electronic Codebook}},
 year = {2002}
 }
 @book{DietaryGuidelines.2005,
 address = {Washington, D.C},
-author = {{U.S.{\$}{\~{}}{\$}Department of Health} and {Human Services} and {U.S. Department of Agriculture}},
+author = {{U.S. Department of Health} and {Human Services} and {U.S. Department of Agriculture}},
 publisher = {Government Printing Office},
-title = {{{\{}D{\}}ietry {\{}G{\}}uidelines for {\{}A{\}}mericans, 2005}},
+title = {{Dietry Guidelines for Americans, 2005}},
 year = {2005}
 }
 @article{Urquiola.2009,
@@ -11208,7 +11208,7 @@ author = {Urquiola, Miguel and Verhoogen, Eric},
 journal = {American Economic Review},
 number = {1},
 pages = {179--215},
-title = {{{\{}C{\}}lass-{\{}S{\}}ize {\{}C{\}}aps, {\{}S{\}}orting, and the {\{}R{\}}egression-{\{}D{\}}iscontinuity {\{}D{\}}esign}},
+title = {{Class-Size Caps, Sorting, and the Regression-Discontinuity Design}},
 volume = {99},
 year = {2009}
 }
@@ -11217,7 +11217,7 @@ author = {Urzua, Sergio},
 journal = {Journal of Human Resources},
 number = {4},
 pages = {919--971},
-title = {{{\{}R{\}}acial {\{}L{\}}abor {\{}M{\}}arket {\{}G{\}}aps:{\$}{\~{}}{\$}{\{}T{\}}he {\{}R{\}}ole of {\{}A{\}}bilities and {\{}S{\}}chooling {\{}C{\}}hoices}},
+title = {{Racial Labor Market Gaps: The Role of Abilities and Schooling Choices}},
 volume = {43},
 year = {2008}
 }
@@ -11233,7 +11233,7 @@ author = {van Buuren, S and Brands and {J. P.} and Groothuis-Oudshoorn and Rubin
 journal = {Journal of Statistical Computation and Simulation},
 number = {12},
 pages = {1046--1049},
-title = {{{\{}F{\}}ully {\{}C{\}}onditional {\{}S{\}}pecification in {\{}M{\}}ultivariate {\{}I{\}}mputation}},
+title = {{Fully Conditional Specification in Multivariate Imputation}},
 volume = {73},
 year = {2005}
 }
@@ -11242,7 +11242,7 @@ author = {van Buuren, S and Brands and {J. P.} and Groothuis-Oudshoorn and Rubin
 journal = {Journal of Statistical Computation and Simulation},
 number = {12},
 pages = {1046--1049},
-title = {{{\{}F{\}}ully {\{}C{\}}onditional {\{}S{\}}pecification in {\{}M{\}}ultivariate {\{}I{\}}mputation}},
+title = {{Fully Conditional Specification in Multivariate Imputation}},
 volume = {73},
 year = {2005}
 }
@@ -11250,7 +11250,7 @@ year = {2005}
 author = {van den Berg, Gerad and Bergemann, Annette and Caliendo, Marco},
 journal = {IZA Discussion Paper},
 pages = {No. 3825},
-title = {{{\{}T{\}}he {\{}E{\}}ffect of {\{}A{\}}ctive {\{}L{\}}abor {\{}M{\}}arket {\{}P{\}}rograms on {\{}N{\}}ot-{\{}Y{\}}et {\{}T{\}}reated {\{}U{\}}nemployed {\{}I{\}}ndividuals}},
+title = {{The Effect of Active Labor Market Programs on Not-Yet Treated Unemployed Individuals}},
 volume = {No. 3825}
 }
 @article{Klaauw.2012,
@@ -11264,7 +11264,7 @@ year = {2012}
 }
 @article{NumPy.2011,
 author = {van der Walt, St�fan and Colbert, S Chris and Varoquaux, Ga�l},
-journal = {Computing in Science {\&} Engineering},
+journal = {Computing in Science \& Engineering},
 number = {2},
 pages = {22--30},
 title = {{The NumPy Array: A Structure for Efficient Numerical Computation}},
@@ -11328,7 +11328,7 @@ author = {Vella, Francis},
 journal = {Journal of Human Resources},
 number = {1},
 pages = {127--169},
-title = {{{\{}E{\}}stimtating {\{}M{\}}odels with {\{}S{\}}ample {\{}S{\}}election {\{}B{\}}ias:{\$}{\~{}}{\$}{\{}A{\}} {\{}S{\}}urvey}},
+title = {{Estimtating Models with Sample Selection Bias: A Survey}},
 volume = {33},
 year = {1998}
 }
@@ -11344,7 +11344,7 @@ author = {Vijverberg, Wim P M},
 journal = {Journal of Econometrics},
 number = {1-3},
 pages = {69--89},
-title = {{{\{}M{\}}easureing the {\{}U{\}}nidentified {\{}P{\}}arameter of the {\{}E{\}}xtended {\{}R{\}}oy {\{}M{\}}odel}},
+title = {{Measureing the Unidentified Parameter of the Extended Roy Model}},
 volume = {57},
 year = {1993}
 }
@@ -11360,12 +11360,12 @@ year = {2005}
 @booklet{Vogel.2006,
 address = {Berlin},
 author = {Vogel, Thorsten},
-title = {{{\{}R{\}}eassessing {\{}I{\}}ntergenerational {\{}M{\}}obility in {\{}G{\}}ermany: {\{}S{\}}ome {\{}N{\}}ew {\{}E{\}}stimation {\{}M{\}}ethods and a {\{}C{\}}omparison of {\{}N{\}}atives and {\{}I{\}}mmigrants}},
+title = {{Reassessing Intergenerational Mobility in Germany: Some New Estimation Methods and a Comparison of Natives and Immigrants}},
 year = {2007}
 }
 @misc{Gaudecker.2010,
 author = {von Gaudecker, Hans-Martin},
-title = {{Effective {\{}P{\}}rogramming {\{}P{\}}ractices for {\{}E{\}}conomists}},
+title = {{Effective Programming Practices for Economists}},
 url = {http://www.uni-bonn.de/{~}hmg308/teaching/prog{\_}econ.html{\#}prog-econ},
 year = {2013}
 }
@@ -11416,22 +11416,22 @@ author = {Vytlacil, Edward J},
 journal = {Econometrica},
 number = {1},
 pages = {331--341},
-title = {{{\{}I{\}}ndependence, {\{}M{\}}onotonicity, and {\{}L{\}}atent {\{}I{\}}ndex {\{}M{\}}odels: {\{}A{\}}n {\{}E{\}}quivalence {\{}R{\}}esult}},
+title = {{Independence, Monotonicity, and Latent Index Models: An Equivalence Result}},
 volume = {70},
 year = {2002}
 }
 @article{Wagner.2007,
-author = {Wagner, Gert G and Frick, Joachim R and Schupp, J{\"{u}}rgen},
+author = {Wagner, Gert G and Frick, Joachim R and Schupp, J\"{u}rgen},
 journal = {SOEPpapers},
 pages = {No. 1},
-title = {{{\{}T{\}}he {\{}G{\}}erman {\{}S{\}}ocio-{\{}E{\}}conomic {\{}P{\}}anel {\{}S{\}}tudy ({\{}S{\}}{\{}O{\}}{\{}E{\}}{\{}P{\}}) - {\{}S{\}}cope, {\{}E{\}}volution and {\{}E{\}}nhancements}},
+title = {{The German Socio-Economic Panel Study (SOEP) - Scope, Evolution and Enhancements}},
 year = {2007}
 }
 @book{Wainer.1986,
 address = {New York, NY},
 editor = {Wainer, H},
 publisher = {Springer},
-title = {{{\{}D{\}}rawing {\{}I{\}}nference from {\{}S{\}}elf-{\{}S{\}}elected {\{}S{\}}amples}},
+title = {{Drawing Inference from Self-Selected Samples}},
 year = {1986}
 }
 @book{Wakker.1989,
@@ -11461,7 +11461,7 @@ author = {Wallis, Kenneth F},
 journal = {Econometrica},
 number = {1},
 pages = {49--73},
-title = {{{\{}E{\}}conometric {\{}I{\}}mplications of the {\{}R{\}}ational {\{}E{\}}xpectations {\{}H{\}}ypothesis}},
+title = {{Econometric Implications of the Rational Expectations Hypothesis}},
 volume = {48},
 year = {1980}
 }
@@ -11512,8 +11512,8 @@ year = {2001}
 }
 @misc{JoachimWeiner.20.01.2008,
 author = {Weiner, Joachim},
-series = {{\{}E{\}}ssay und {\{}D{\}}iskurs},
-title = {{{\{}L{\}}eitbilder der {\{}G{\}}egenwartsgesellschaft}}
+series = {Essay und Diskurs},
+title = {{Leitbilder der Gegenwartsgesellschaft}}
 }
 @article{Weiss.2013,
 author = {Weiss, Michael J and Bloom, Howard S and Brock, Thomas},
@@ -11561,7 +11561,7 @@ year = {2001}
 author = {Whalley, Lawrence J and Deary, Ian J},
 journal = {British Medical Journal},
 pages = {819--822},
-title = {{{\{}L{\}}ongitudinal {\{}C{\}}ohort {\{}S{\}}tudy of {\{}C{\}}hildhood {\{}I{\}}{\{}Q{\}} and {\{}S{\}}urvival up to {\{}A{\}}ge 76}},
+title = {{Longitudinal Cohort Study of Childhood IQ and Survival up to Age 76}},
 volume = {322},
 year = {2001}
 }
@@ -11575,7 +11575,7 @@ number = {7},
 pages = {1072--1077},
 pmid = {10394318},
 title = {{Child outcomes when child care center classes meet recommended standards for quality. NICHD Early Child Care Research Network.}},
-url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1508829{\&}tool=pmcentrez{\&}rendertype=abstract},
+url = {http://www.pubmedcentral.nih.gov/articlerender.fcgi?artid=1508829&tool=pmcentrez&rendertype=abstract},
 volume = {89},
 year = {1999}
 }
@@ -11606,7 +11606,7 @@ year = {1998}
 author = {Whitehurst, Grover J and Lonigan, Christopher J},
 journal = {Child},
 pages = {848--872},
-title = {{{\{}C{\}}hild {\{}D{\}}evelopment and {\{}E{\}}mergent {\{}L{\}}iteracy}},
+title = {{Child Development and Emergent Literacy}},
 volume = {69},
 year = {1998}
 }
@@ -11622,7 +11622,7 @@ year = {2011}
 @article{Wiegand.1997,
 author = {Wiegand, Johannes},
 journal = {Working Paper},
-title = {{{\{}I{\}}ntergenerational {\{}M{\}}obility in {\{}G{\}}ermany}},
+title = {{Intergenerational Mobility in Germany}},
 volume = {University},
 year = {1997}
 }
@@ -11638,7 +11638,7 @@ year = {2008}
 @article{Williams.2009,
 author = {Williams, Benjamin},
 journal = {Working Paper},
-title = {{{\{}I{\}}dentification of {\{}R{\}}ank under {\{}P{\}}artial {\{}I{\}}nformation}},
+title = {{Identification of Rank under Partial Information}},
 volume = {The Univer},
 year = {2009}
 }
@@ -11647,13 +11647,13 @@ author = {Willis, Robert and Rosen, Sherwin},
 journal = {Journal of Political Economy},
 number = {5},
 pages = {S7----S36},
-title = {{{\{}E{\}}ducation and {\{}S{\}}elf-{\{}S{\}}election}},
+title = {{Education and Self-Selection}},
 volume = {87},
 year = {1979}
 }
 @misc{Wilson.2013,
 author = {Wilson, Greg},
-title = {{{\{}S{\}}oftware {\{}C{\}}arpentry {\{}W{\}}eb {\{}S{\}}ite}},
+title = {{Software Carpentry Web Site}},
 url = {http://software-carpentry.org},
 year = {2013}
 }
@@ -11666,11 +11666,11 @@ year = {2014}
 @incollection{Winship.2007,
 address = {New York, NY},
 author = {Winship, Christopher and Korenman, Sanders},
-booktitle = {{\{}I{\}}ntelligence, {\{}G{\}}enes, and {\{}S{\}}uccess: {\{}S{\}}cientists {\{}R{\}}esponse to the {\{}B{\}}ell {\{}C{\}}urve},
+booktitle = {Intelligence, Genes, and Success: Scientists Response to the Bell Curve},
 editor = {Devlin, Bernie and Fienberg, Stephen E and Resnick, Daniel P and Roeder, Kathryn},
 pages = {215--234},
 publisher = {Springer},
-title = {{{\{}D{\}}oes {\{}S{\}}taying in {\{}S{\}}chool make you {\{}S{\}}marter? {\{}T{\}}he {\{}E{\}}ffect of {\{}E{\}}ducation on {\{}I{\}}{\{}Q{\}}{\$}{\~{}}{\$}in {\{}T{\}}he {\{}B{\}}ell{\$}{\~{}}{\$}{\{}C{\}}urve}},
+title = {{Does Staying in School make you Smarter? The Effect of Education on IQ in The Bell Curve}},
 year = {2007}
 }
 @article{Wise.1985a,
@@ -11694,7 +11694,7 @@ author = {Wolfe, Barbara},
 journal = {Medical Care},
 number = {10},
 pages = {1127--1138},
-title = {{{\{}T{\}}he {\{}I{\}}nfluence of {\{}H{\}}ealth on {\{}S{\}}chool {\{}O{\}}utcomes:{\$}{\~{}}{\$}{\{}A{\}} {\{}M{\}}ultivariate {\{}A{\}}pproach}},
+title = {{The Influence of Health on School Outcomes: A Multivariate Approach}},
 volume = {23},
 year = {1985}
 }
@@ -11712,7 +11712,7 @@ author = {Wolpin, Kenneth I},
 journal = {American Economic Review},
 number = {2},
 pages = {48--52},
-title = {{{\{}E{\}}x {\{}A{\}}nte {\{}P{\}}olicy {\{}E{\}}valuation, {\{}S{\}}tructural {\{}E{\}}stimation, and {\{}M{\}}odel {\{}S{\}}election}},
+title = {{Ex Ante Policy Evaluation, Structural Estimation, and Model Selection}},
 volume = {97},
 year = {2007}
 }
@@ -11751,14 +11751,14 @@ keywords = {mas,multi-agent},
 pages = {484},
 publisher = {Wiley},
 title = {{An Introduction to MultiAgent Systems [Paperback]}},
-url = {https://www.google.com/books?hl=hr{\&}lr={\&}id=X3ZQ7yeDn2IC{\&}oi=fnd{\&}pg=PR13{\&}dq=Wooldridge,+M.,+An+introduction+to+multiagent+systems.+2009:+John+Wiley+{\%}26+Sons{\&}ots=WFoevw8u54{\&}sig=pW{\_}SoLDnMqc6fkrAnJzFJIv8phI{\%}5Cnhttp://www.amazon.com/Introduction-MultiAgent-Syste},
+url = {https://www.google.com/books?hl=hr&lr=&id=X3ZQ7yeDn2IC&oi=fnd&pg=PR13&dq=Wooldridge,+M.,+An+introduction+to+multiagent+systems.+2009:+John+Wiley+{\%}26+Sons&ots=WFoevw8u54&sig=pW{\_}SoLDnMqc6fkrAnJzFJIv8phI{\%}5Cnhttp://www.amazon.com/Introduction-MultiAgent-Syste},
 year = {2009}
 }
 @article{Wooldrige.2003,
 author = {Wooldrige, Jeffrey M},
 journal = {Economic Letters},
 pages = {186--191},
-title = {{{\{}F{\}} urther results on instrumental variables estimation of average treatment effects in the correlated random coefficient model}},
+title = {{F urther results on instrumental variables estimation of average treatment effects in the correlated random coefficient model}},
 volume = {79},
 year = {2003}
 }
@@ -11766,22 +11766,22 @@ year = {2003}
 author = {Wooldrige, Jeffrey M},
 journal = {Economic Letters},
 pages = {1133--1239},
-title = {{{\{}O{\}}n two stage least squares estimation of the average treatment effect in a random coefficient model}},
+title = {{On two stage least squares estimation of the average treatment effect in a random coefficient model}},
 volume = {56},
 year = {1997}
 }
 @book{Wooldrige.2002,
 address = {Cambridge, MA},
 author = {Wooldrige, Jeffrey M},
-publisher = {MIT{\$}{\~{}}{\$}Press},
-title = {{{\{}E{\}}conometric {\{}A{\}}nalysis of {\{}C{\}}ross {\{}S{\}}ection and {\{}P{\}}anel {\{}D{\}}ata}},
+publisher = {MIT Press},
+title = {{Econometric Analysis of Cross Section and Panel Data}},
 year = {2002}
 }
 @book{WHO.2008,
 address = {Copenhagen, Denmark},
 author = {{World Health Organization}},
-publisher = {WHO{\$}{\~{}}{\$}Publications},
-title = {{{\{}I{\}}nequalities in {\{}Y{\}}oung {\{}P{\}}eople's {\{}H{\}}ealth}},
+publisher = {WHO Publications},
+title = {{Inequalities in Young People's Health}},
 year = {2008}
 }
 @article{Xu.2012,
@@ -11797,7 +11797,7 @@ year = {2012}
 address = {Cambridge, MA},
 author = {Xu, Huan and Mannor, Shie},
 booktitle = {Advances in Neural Information Processing Systems 19},
-editor = {Sch{\"{o}}lkopf, B and Platt, J C and Hoffman, T},
+editor = {Sch\"{o}lkopf, B and Platt, J C and Hoffman, T},
 pages = {1537--1544},
 publisher = {MIT Press},
 title = {{The Robustness-Performance Tradeoff in Markov Decision Processes}},
@@ -11808,7 +11808,7 @@ author = {Yakowitz, Sidney J and Spragins, John D},
 journal = {The Annals of Mathematical Statistics},
 number = {1},
 pages = {209--214},
-title = {{{\{}O{\}}n the {\{}I{\}}dentifiability of {\{}F{\}}inite {\{}M{\}}ixtures}},
+title = {{On the Identifiability of Finite Mixtures}},
 volume = {39},
 year = {1968}
 }
@@ -11816,7 +11816,7 @@ year = {1968}
 author = {Yen, Cherng-Jyh and Konold, Timothy R and McDermott, Paul A},
 journal = {Journal of School Psychology},
 pages = {157--169},
-title = {{{\{}D{\}}oes {\{}L{\}}earning {\{}B{\}}ehavior {\{}A{\}}ugment {\{}C{\}}ognitive {\{}A{\}}bility as an {\{}I{\}}ndicator of {\{}A{\}}cademic {\{}A{\}}chievement?}},
+title = {{Does Learning Behavior Augment Cognitive Ability as an Indicator of Academic Achievement?}},
 volume = {42},
 year = {2004}
 }
@@ -11825,7 +11825,7 @@ author = {Yeung, W Jean and Linver, Miriam R and Brooks-Gunn, Jeanne},
 journal = {Child Development},
 number = {6},
 pages = {1861--1897},
-title = {{{\{}H{\}}ow {\{}M{\}}oney {\{}M{\}}atters for {\{}Y{\}}oung {\{}C{\}}hildren's {\{}D{\}}evelopment:{\$}{\~{}}{\$}{\{}P{\}}arental {\{}I{\}}nvestment and {\{}F{\}}amily {\{}P{\}}rocesses}},
+title = {{How Money Matters for Young Children's Development: Parental Investment and Family Processes}},
 volume = {73},
 year = {2002}
 }
@@ -11834,7 +11834,7 @@ author = {Yildiz, Nese and Vytlacil, Edward J},
 journal = {Econometrica},
 number = {3},
 pages = {759--779},
-title = {{{\{}D{\}}ummy {\{}E{\}}ndogenous {\{}V{\}}ariables in {\{}W{\}}eakly {\{}S{\}}eparable {\{}M{\}}odels}},
+title = {{Dummy Endogenous Variables in Weakly Separable Models}},
 volume = {75},
 year = {2007}
 }
@@ -11851,7 +11851,7 @@ year = {1969}
 address = {New York, NY},
 editor = {Zarembka, Paul},
 publisher = {Academic Press},
-title = {{{\{}F{\}}rontiers in {\{}E{\}}conometrics}},
+title = {{Frontiers in Econometrics}},
 year = {1974}
 }
 @article{Zellner.1970,
@@ -11859,7 +11859,7 @@ author = {Zellner, Arnold},
 journal = {International Economic Review},
 number = {3},
 pages = {441--454},
-title = {{{\{}E{\}}stimation of {\{}R{\}}egression {\{}R{\}}elationships {\{}C{\}}ontaining {\{}U{\}}nobservable {\{}I{\}}ndependent {\{}V{\}}ariables}},
+title = {{Estimation of Regression Relationships Containing Unobservable Independent Variables}},
 volume = {11},
 year = {1970}
 }
@@ -11868,7 +11868,7 @@ author = {Zelon, Helen},
 journal = {Citylimits},
 number = {1},
 pages = {5--37},
-title = {{{\{}I{\}}s the {\{}P{\}}romise {\{}R{\}}eal? {\{}T{\}}he {\{}H{\}}arlem {\{}C{\}}hildren's {\{}Z{\}}one {\{}B{\}}ecomes a {\{}T{\}}emplate for {\{}N{\}}ational {\{}C{\}}hange}},
+title = {{Is the Promise Real? The Harlem Children's Zone Becomes a Template for National Change}},
 volume = {34},
 year = {2010}
 }


### PR DESCRIPTION
# Problem
Mendeley has an innocent option under **Tools/Option/BibTex** called *Escape LaTex special characters (#{}%&)*. This creates a ***mess***.

Because if you export the .bib file, escape expressions are generated for every character in the list. Note that, there were already some latex fragments in the .bib file plus links , other expressions included characters of the list.

Do these two steps, importing, exporting, a few times and you get huge complex latex escape expressions in the file which will eventually fail and produce mistakes like the one with Keane, Wolpin (2011).

# Solution
First, don't tick the option. Second, I used regular expression to clean the file from fragments. Here is the list of the expressions used:
- Escape öäü:
````
\{(\\"\{[AOUoua]\})\}
````
- Escape big letters in {}:
````
\{([A-Z])\}
````
- & character:
````
\{\\(&)\}
````
to delete escaped & and
````
\s&\s
````
to find ordinary & in citations to escape again.

- Delete whitespace string (not re):
````
{\$}{\~{}}{\$}
````

# Note
Only ``literature.bib`` is fixed.